### PR TITLE
feat(github): add guarded founder actor enrollment

### DIFF
--- a/cloudflare/worker/README.md
+++ b/cloudflare/worker/README.md
@@ -144,6 +144,10 @@ Configure the non-secret values as Worker variables:
 - `TF_GITHUB_APP_SLUG`
 - `TF_GITHUB_APP_CLIENT_ID`
 - `TF_GITHUB_APP_CALLBACK_URL` (`https://<worker>/v1/github/callback`)
+- `TF_GITHUB_EXPECTED_ORG` (`thoughtseed-labs`)
+- `TF_GITHUB_EXPECTED_ORG_ID` (`65741640`)
+- `TF_GITHUB_ALLOWED_ACTORS`
+  (`Sheshiyer:7611727,psychon7:47470954`; `login:numeric-user-id` pairs)
 
 Configure secret values with `wrangler secret put`:
 
@@ -160,6 +164,14 @@ Cloudflare Access and resolves a registered Plexus principal; connection,
 repository selection, verification, and writes require a workspace admin.
 Activity sync is available to active registered workspace members for their
 same-workspace project.
+
+Each founder enrolls separately through GitHub App OAuth. During actor
+enrollment, the Worker uses the ephemeral GitHub user access token only for
+`GET /user` and `GET /user/installations`, requires access to the workspace's
+already-bound installation ID, and then discards the token. D1 stores only the
+verified numeric GitHub user ID, login snapshot, and Plexus identity mapping.
+Login text is never sufficient authority: the configured login and immutable
+numeric user ID must both match.
 
 Subscribe the App to the `installation` and `installation_repositories`
 webhook events. During installation, choose **Only select repositories** and
@@ -185,6 +197,8 @@ Routes:
 
 - `GET /v1/github/connection`
 - `POST /v1/github/connect/start`
+- `GET /v1/github/actor`
+- `POST /v1/github/actor/enroll/start`
 - `GET /v1/github/repositories`
 - `POST /v1/projects/:projectId/github-repo/verify`
 - `POST /v1/projects/:projectId/github-activity/sync`
@@ -192,11 +206,20 @@ Routes:
 - `GET /v1/github/callback` (public, signed single-use state)
 - `POST /v1/github/webhook` (public, `X-Hub-Signature-256`)
 
-Apply migration `0012_github_app_control_plane.sql` before enabling the routes.
+Apply migrations `0012_github_app_control_plane.sql` and
+`0013_github_workspace_actors.sql` before enabling the routes.
 It stores OAuth/install correlation state, immutable signed installation
 facts, workspace bindings, numeric repositories, delivery dedupe/leases,
 project verification, and idempotent write receipts. It stores no OAuth token,
 installation token, client secret, webhook secret, or private key.
+
+Immediate founder revocation is fail-closed: remove the founder's
+`login:numeric-id` pair from `TF_GITHUB_ALLOWED_ACTORS` or revoke their active
+Plexus administrator role. Every guarded write rechecks both controls and then
+rechecks the actor's live numeric repository permission before mutation. A
+local organization-membership preflight is setup guidance only; server
+authority is the pinned founder IDs, pinned bound organization installation,
+active Plexus admin, and live per-repository permission.
 
 ### Founder inputs before setup
 

--- a/cloudflare/worker/migrations/0013_github_workspace_actors.sql
+++ b/cloudflare/worker/migrations/0013_github_workspace_actors.sql
@@ -1,0 +1,63 @@
+-- Per-Plexus-member GitHub actor enrollment. OAuth access tokens are exchanged
+-- only long enough to resolve /user plus bound installation access and are
+-- never stored in D1.
+
+CREATE TABLE IF NOT EXISTS github_actor_connection_states (
+  nonce_hash TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  plexus_identity_id TEXT NOT NULL,
+  expires_at INTEGER NOT NULL,
+  consumed_at TEXT,
+  oauth_user_id INTEGER,
+  oauth_login TEXT,
+  status TEXT NOT NULL DEFAULT 'pending_oauth'
+    CHECK (status IN ('pending_oauth', 'bound', 'expired', 'rejected')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+  FOREIGN KEY (plexus_identity_id) REFERENCES plexus_identities(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_actor_states_identity
+  ON github_actor_connection_states(workspace_id, plexus_identity_id, status, expires_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_github_actor_states_one_active_identity
+  ON github_actor_connection_states(workspace_id, plexus_identity_id)
+  WHERE status = 'pending_oauth';
+
+CREATE TABLE IF NOT EXISTS github_workspace_actors (
+  workspace_id TEXT NOT NULL,
+  plexus_identity_id TEXT NOT NULL,
+  github_user_id INTEGER NOT NULL,
+  github_login TEXT NOT NULL,
+  verified_at TEXT NOT NULL,
+  verification_source TEXT NOT NULL CHECK (verification_source IN ('installation', 'oauth')),
+  connection_nonce_hash TEXT UNIQUE,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (workspace_id, plexus_identity_id),
+  UNIQUE (workspace_id, github_user_id),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+  FOREIGN KEY (plexus_identity_id) REFERENCES plexus_identities(id) ON DELETE CASCADE,
+  FOREIGN KEY (connection_nonce_hash) REFERENCES github_actor_connection_states(nonce_hash) ON DELETE RESTRICT
+);
+
+CREATE INDEX IF NOT EXISTS idx_github_workspace_actors_user
+  ON github_workspace_actors(workspace_id, github_user_id);
+
+-- Preserve the verified installation owner as the first enrolled actor. The
+-- configured login-and-numeric-ID policy is still enforced before any write.
+INSERT OR IGNORE INTO github_workspace_actors (
+  workspace_id, plexus_identity_id, github_user_id, github_login, verified_at,
+  verification_source, connection_nonce_hash, created_at, updated_at
+)
+SELECT
+  workspace_id,
+  connected_by_identity_id,
+  verified_github_user_id,
+  verified_github_login,
+  updated_at,
+  'installation',
+  NULL,
+  created_at,
+  updated_at
+FROM github_workspace_installations;

--- a/cloudflare/worker/src/lib/env.ts
+++ b/cloudflare/worker/src/lib/env.ts
@@ -63,6 +63,11 @@ export interface Env {
   TF_GITHUB_APP_CALLBACK_URL?: string;
   TF_GITHUB_APP_WEBHOOK_SECRET?: string;
   TF_GITHUB_APP_STATE_SIGNING_SECRET?: string;
+  // Non-secret enrollment policy. Login names are hints/gates at OAuth time;
+  // durable actor authority is always the verified numeric GitHub user ID.
+  TF_GITHUB_EXPECTED_ORG?: string;
+  TF_GITHUB_EXPECTED_ORG_ID?: string;
+  TF_GITHUB_ALLOWED_ACTORS?: string;
   TF_INTEGRATION_CONFIG_JSON?: string;
   TF_CREDENTIAL_ENVELOPE_KEY?: string;
   TF_WEBHOOK_HMAC_SECRET?: string;

--- a/cloudflare/worker/src/lib/github-app.ts
+++ b/cloudflare/worker/src/lib/github-app.ts
@@ -245,7 +245,7 @@ export class GithubAppClient {
     return `${signingInput}.${bytesToBase64Url(signature)}`;
   }
 
-  async exchangeOauthCode(code: string): Promise<GithubUser> {
+  async exchangeOauthCode(code: string, requiredInstallationId?: number): Promise<GithubUser> {
     const config = requireGithubAppEnv(this.env);
     const tokenResponse = await this.fetchImpl("https://github.com/login/oauth/access_token", {
       method: "POST",
@@ -262,8 +262,34 @@ export class GithubAppClient {
     const userResponse = await this.fetchImpl(`${GITHUB_API}/user`, {
       headers: this.headers(tokenBody.access_token),
     });
-    const user = await responseJson<GithubUser>(userResponse, "github_oauth_identity_failed");
+    const user = await responseJson<Pick<GithubUser, "id" | "login">>(userResponse, "github_oauth_identity_failed");
     if (!Number.isSafeInteger(user.id) || !user.login) throw new GithubControlPlaneError("github_oauth_identity_failed", "GitHub OAuth identity is invalid.", 502);
+    if (requiredInstallationId !== undefined) {
+      if (!Number.isSafeInteger(requiredInstallationId) || requiredInstallationId <= 0) {
+        throw new GithubControlPlaneError("github_installation_hint_invalid", "Installation ID must be numeric.", 400);
+      }
+      let installationAccessible = false;
+      for (let page = 1; page <= 10; page += 1) {
+        const installationsResponse = await this.fetchImpl(`${GITHUB_API}/user/installations?per_page=100&page=${page}`, {
+          headers: this.headers(tokenBody.access_token),
+        });
+        const installations = await responseJson<{ installations?: Array<{ id?: number }> }>(
+          installationsResponse,
+          "github_oauth_installations_failed",
+        );
+        if (!Array.isArray(installations.installations)) {
+          throw new GithubControlPlaneError("github_oauth_installations_failed", "GitHub App installation authority is invalid.", 502);
+        }
+        if (installations.installations.some((installation) => installation.id === requiredInstallationId)) {
+          installationAccessible = true;
+          break;
+        }
+        if (installations.installations.length < 100) break;
+      }
+      if (!installationAccessible) {
+        throw new GithubControlPlaneError("github_oauth_installation_forbidden", "GitHub OAuth identity cannot access the workspace installation.", 403);
+      }
+    }
     return { id: user.id, login: user.login };
   }
 

--- a/cloudflare/worker/src/routes/__tests__/github.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/github.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { D1DatabaseLike, Env } from "../../lib/env";
 import type { PlexusPrincipal } from "../../lib/plexus-session";
-import { handleGithubActivitySync, handleGithubCallback, handleGithubConnection, handleGithubPullRequest, handleGithubRepoVerify, handleGithubWebhook, nextInstallationState, reconcileBinding, validateWriteFiles } from "../github";
+import { handleGithubActivitySync, handleGithubActor, handleGithubActorEnrollStart, handleGithubCallback, handleGithubConnection, handleGithubPullRequest, handleGithubRepoVerify, handleGithubWebhook, nextInstallationState, reconcileBinding, validateWriteFiles } from "../github";
 import { sha256Hex, signConnectState } from "../../lib/github-app";
 
 let privateKeyPem = "";
@@ -115,7 +115,9 @@ function writeDb(existing: Record<string, unknown> | null = null): { db: D1Datab
         bind(...values: unknown[]) { args = values; return statement; },
         async first<T>() {
           if (sql.includes("FROM projects WHERE id")) return ({ id: args[0] } as T);
-          if (sql.includes("FROM github_workspace_installations b")) return ({ workspace_id: "ws_test", installation_id: 42, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected" } as T);
+          if (sql.includes("FROM plexus_identities")) return ({ id: "pid_admin" } as T);
+          if (sql.includes("FROM github_workspace_actors")) return ({ workspace_id: "ws_test", plexus_identity_id: "pid_admin", github_user_id: 77, github_login: "installer", verified_at: "2026-07-13T00:00:00.000Z", verification_source: "oauth" } as T);
+          if (sql.includes("FROM github_workspace_installations b")) return ({ workspace_id: "ws_test", installation_id: 42, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
           if (sql.includes("FROM project_github_verifications v")) return ({ project_id: "proj_test", workspace_id: "ws_test", installation_id: 42, repository_id: 101, repo_owner: "thoughtseed", repo_name: "private-repo", default_branch: "main", verified_at: "2026-07-13T00:00:00.000Z", owner_login: "thoughtseed", name: "private-repo", full_name: "thoughtseed/private-repo", is_private: 1, state: "active" } as T);
           if (sql.includes("FROM github_write_operations")) return (existing as T | null);
           return null;
@@ -182,7 +184,11 @@ function guardedWriteFetch(permission: unknown, options: { staleBase?: boolean; 
   return { fetcher, mutations, tokenRequest: () => tokenRequest };
 }
 
-function reconciliationDb(repositorySelection: string, actorActive: boolean) {
+function reconciliationDb(
+  repositorySelection: string,
+  actorActive: boolean,
+  organization: { id: number; login: string; type: string } = { id: 8, login: "thoughtseed", type: "Organization" },
+) {
   let bound = false;
   const state = { nonce_hash: "nonce-hash", workspace_id: "ws_test", plexus_actor_id: "pid_admin", expires_at: Math.floor(Date.now() / 1000) + 600, consumed_at: "now", oauth_user_id: 77, oauth_login: "installer", oauth_verified_at: "now", untrusted_installation_id: 42, status: "oauth_verified" };
   const db: D1DatabaseLike = {
@@ -193,7 +199,8 @@ function reconciliationDb(repositorySelection: string, actorActive: boolean) {
         async first<T>() {
           if (sql.includes("FROM github_connection_states")) return ({ ...state } as T);
           if (sql.includes("FROM plexus_identities")) return (actorActive ? ({ id: "pid_admin" } as T) : null);
-          if (sql.includes("FROM github_installation_facts")) return ({ installation_id: Number(args[0]), installer_sender_id: 77, repository_selection: repositorySelection, state: "active" } as T);
+          if (sql.includes("FROM github_installation_facts")) return ({ installation_id: Number(args[0]), installer_sender_id: 77, account_id: organization.id, account_login: organization.login, account_type: organization.type, repository_selection: repositorySelection, state: "active" } as T);
+          if (sql.includes("FROM github_workspace_actors")) return null;
           if (sql.includes("FROM github_workspace_installations")) return null;
           return null;
         },
@@ -288,6 +295,70 @@ function connectionFlowDb(nonceHash: string) {
   return { db, state, binding: () => binding };
 }
 
+function actorEnrollmentDb(
+  initialActor: Record<string, unknown> | null = null,
+  concurrentActor: Record<string, unknown> | null = null,
+) {
+  let actorState: Record<string, unknown> | null = null;
+  let actor: Record<string, unknown> | null = initialActor;
+  const runs: Array<{ sql: string; args: unknown[] }> = [];
+  const db: D1DatabaseLike = {
+    prepare(sql: string) {
+      let args: unknown[] = [];
+      const statement = {
+        bind(...values: unknown[]) { args = values; return statement; },
+        async first<T>() {
+          if (sql.includes("FROM plexus_identities")) return ({ id: "pid_admin" } as T);
+          if (sql.includes("FROM github_workspace_installations b")) {
+            return ({ workspace_id: "ws_test", installation_id: 42, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
+          }
+          if (sql.includes("FROM github_actor_connection_states")) {
+            if (!actorState) return null;
+            if (sql.includes("nonce_hash = ?")) return (actorState.nonce_hash === args[0] ? ({ ...actorState } as T) : null);
+            return ({ ...actorState } as T);
+          }
+          if (sql.includes("FROM github_workspace_actors")) {
+            if (sql.includes("github_user_id = ?") && actor && actor.github_user_id === args[1] && actor.plexus_identity_id !== args[2]) {
+              return ({ plexus_identity_id: actor.plexus_identity_id } as T);
+            }
+            return (actor ? ({ ...actor } as T) : null);
+          }
+          return null;
+        },
+        async all<T>() { return { results: [] as T[] }; },
+        async run() {
+          runs.push({ sql, args: [...args] });
+          if (sql.includes("INSERT INTO github_actor_connection_states")) {
+            actorState = {
+              nonce_hash: args[0], workspace_id: args[1], plexus_identity_id: args[2], expires_at: args[3],
+              consumed_at: null, oauth_user_id: null, oauth_login: null, status: "pending_oauth",
+            };
+          } else if (sql.includes("SET consumed_at") && sql.includes("github_actor_connection_states")) {
+            if (!actorState || actorState.consumed_at) return { success: true, meta: { changes: 0 } };
+            actorState.consumed_at = args[0];
+          } else if (sql.includes("INSERT INTO github_workspace_actors")) {
+            if (!actor && concurrentActor) actor = { ...concurrentActor };
+            if (actor && actor.github_user_id !== args[2]) return { success: true, meta: { changes: 0 } };
+            actor = {
+              workspace_id: args[0], plexus_identity_id: args[1], github_user_id: args[2], github_login: args[3],
+              verified_at: args[4], verification_source: args[5], connection_nonce_hash: args[6],
+            };
+          } else if (sql.includes("SET oauth_user_id") && sql.includes("github_actor_connection_states") && actorState) {
+            actorState.oauth_user_id = args[0];
+            actorState.oauth_login = args[1];
+            actorState.status = "bound";
+          } else if (sql.includes("status = 'rejected'") && sql.includes("github_actor_connection_states") && actorState) {
+            actorState.status = "rejected";
+          }
+          return { success: true, meta: { changes: 1 } };
+        },
+      };
+      return statement;
+    },
+  };
+  return { db, actor: () => actor, state: () => actorState, runs };
+}
+
 function env(db: D1DatabaseLike): Env {
   return {
     TF_ENV: "test",
@@ -298,7 +369,11 @@ function env(db: D1DatabaseLike): Env {
     TF_GITHUB_APP_CLIENT_ID: "Iv1.test",
     TF_GITHUB_APP_CLIENT_SECRET: "secret",
     TF_GITHUB_APP_CALLBACK_URL: "https://worker.test/v1/github/callback",
+    TF_GITHUB_APP_WEBHOOK_SECRET: "webhook-test-secret",
     TF_GITHUB_APP_STATE_SIGNING_SECRET: "s".repeat(32),
+    TF_GITHUB_EXPECTED_ORG: "thoughtseed",
+    TF_GITHUB_EXPECTED_ORG_ID: "8",
+    TF_GITHUB_ALLOWED_ACTORS: "installer:77,Sheshiyer:7611727,psychon7:47470954",
   };
 }
 
@@ -317,6 +392,176 @@ describe("GitHub App routes", () => {
     expect(() => validateWriteFiles([{ path: "src/../secret", content: "x" }])).toThrow(/unsafe/);
     expect(() => validateWriteFiles([{ path: "src/a\u0000.ts", content: "x" }])).toThrow(/unsafe/);
     expect(() => validateWriteFiles([{ path: "src/a.ts", content: "x" }, { path: "src/a.ts", content: "y" }])).toThrow(/unsafe/);
+  });
+
+  it("enrolls an active Plexus administrator through one-time OAuth and stores only the numeric actor", async () => {
+    const fixture = actorEnrollmentDb();
+    const actorEnv = { ...env(fixture.db), TF_GITHUB_ALLOWED_ACTORS: "Sheshiyer:7611727,psychon7:47470954" };
+    const start = await handleGithubActorEnrollStart(actorEnv, principal("admin"));
+    expect(start.status).toBe(201);
+    const startPayload = await start.json() as { data: { authorizeUrl: string; organization: { id: number; login: string } } };
+    expect(startPayload.data.organization).toEqual({ id: 8, login: "thoughtseed" });
+    const stateValue = new URL(startPayload.data.authorizeUrl).searchParams.get("state");
+    expect(stateValue).toBeTruthy();
+
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://github.com/login/oauth/access_token") return new Response(JSON.stringify({ access_token: "ephemeral-oauth-token" }));
+      if (url === "https://api.github.com/user") return new Response(JSON.stringify({ id: 7611727, login: "Sheshiyer" }));
+      if (url === "https://api.github.com/user/installations?per_page=100&page=1") return new Response(JSON.stringify({ installations: [{ id: 42 }] }));
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+    const callback = await handleGithubCallback(
+      actorEnv,
+      new Request("https://worker.test/v1/github/callback"),
+      new URL(`https://worker.test/v1/github/callback?state=${encodeURIComponent(stateValue!)}&code=one-time-code`),
+    );
+    expect(callback.status).toBe(200);
+    expect(fixture.actor()).toMatchObject({ github_user_id: 7611727, github_login: "Sheshiyer", plexus_identity_id: "pid_admin", verification_source: "oauth" });
+    expect(JSON.stringify(fixture.runs)).not.toContain("ephemeral-oauth-token");
+
+    const status = await handleGithubActor(actorEnv, principal("admin"));
+    await expect(status.json()).resolves.toMatchObject({ data: { status: "verified", actor: { id: 7611727, login: "Sheshiyer" } } });
+    const replay = await handleGithubCallback(
+      actorEnv,
+      new Request("https://worker.test/v1/github/callback"),
+      new URL(`https://worker.test/v1/github/callback?state=${encodeURIComponent(stateValue!)}&code=replayed-code`),
+    );
+    expect(replay.status).toBe(409);
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    ["inaccessible bound installation", 7611727, [{ id: 99 }], "github_oauth_installation_forbidden", 403],
+    ["recycled allowed login with wrong numeric ID", 999, [{ id: 42 }], "github_actor_forbidden", 403],
+    ["malformed installation authority", 7611727, null, "github_oauth_installations_failed", 502],
+  ])("rejects OAuth actor enrollment for %s", async (_label, userId, installations, expectedCode, expectedStatus) => {
+    const fixture = actorEnrollmentDb();
+    const actorEnv = { ...env(fixture.db), TF_GITHUB_ALLOWED_ACTORS: "Sheshiyer:7611727,psychon7:47470954" };
+    const start = await handleGithubActorEnrollStart(actorEnv, principal("admin"));
+    const startPayload = await start.json() as { data: { authorizeUrl: string } };
+    const stateValue = new URL(startPayload.data.authorizeUrl).searchParams.get("state");
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("oauth/access_token")) return new Response(JSON.stringify({ access_token: "ephemeral-oauth-token" }));
+      if (url.endsWith("/user")) return new Response(JSON.stringify({ id: userId, login: "Sheshiyer" }));
+      if (url.includes("/user/installations?")) {
+        return new Response(JSON.stringify(installations === null ? {} : { installations }));
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+    const callback = await handleGithubCallback(
+      actorEnv,
+      new Request("https://worker.test/v1/github/callback"),
+      new URL(`https://worker.test/v1/github/callback?state=${encodeURIComponent(stateValue!)}&code=one-time-code`),
+    );
+    expect(callback.status).toBe(expectedStatus);
+    await expect(callback.json()).resolves.toMatchObject({ error: { code: expectedCode } });
+    expect(fixture.actor()).toBeNull();
+    expect(fixture.state()).toMatchObject({ status: "rejected" });
+    expect(JSON.stringify(fixture.runs)).not.toContain("ephemeral-oauth-token");
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects rebinding one Plexus identity across the two founder numeric IDs", async () => {
+    const fixture = actorEnrollmentDb({
+      workspace_id: "ws_test",
+      plexus_identity_id: "pid_admin",
+      github_user_id: 7611727,
+      github_login: "Sheshiyer",
+      verified_at: "2026-07-13T00:00:00.000Z",
+      verification_source: "oauth",
+    });
+    const actorEnv = { ...env(fixture.db), TF_GITHUB_ALLOWED_ACTORS: "Sheshiyer:7611727,psychon7:47470954" };
+    const start = await handleGithubActorEnrollStart(actorEnv, principal("admin"));
+    const payload = await start.json() as { data: { authorizeUrl: string } };
+    const stateValue = new URL(payload.data.authorizeUrl).searchParams.get("state");
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("oauth/access_token")) return new Response(JSON.stringify({ access_token: "ephemeral-oauth-token" }));
+      if (url.endsWith("/user")) return new Response(JSON.stringify({ id: 47470954, login: "psychon7" }));
+      if (url.includes("/user/installations?")) return new Response(JSON.stringify({ installations: [{ id: 42 }] }));
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+    const callback = await handleGithubCallback(
+      actorEnv,
+      new Request("https://worker.test/v1/github/callback"),
+      new URL(`https://worker.test/v1/github/callback?state=${encodeURIComponent(stateValue!)}&code=one-time-code`),
+    );
+    expect(callback.status).toBe(409);
+    await expect(callback.json()).resolves.toMatchObject({ error: { code: "github_actor_rebind_forbidden" } });
+    expect(fixture.actor()).toMatchObject({ github_user_id: 7611727, github_login: "Sheshiyer" });
+    expect(fixture.state()).toMatchObject({ status: "rejected" });
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the first founder binding when a concurrent CAS update reports zero changes", async () => {
+    const concurrentFounder = {
+      workspace_id: "ws_test",
+      plexus_identity_id: "pid_admin",
+      github_user_id: 47470954,
+      github_login: "psychon7",
+      verified_at: "2026-07-13T00:00:00.000Z",
+      verification_source: "oauth",
+    };
+    const fixture = actorEnrollmentDb(null, concurrentFounder);
+    const actorEnv = { ...env(fixture.db), TF_GITHUB_ALLOWED_ACTORS: "Sheshiyer:7611727,psychon7:47470954" };
+    const start = await handleGithubActorEnrollStart(actorEnv, principal("admin"));
+    const payload = await start.json() as { data: { authorizeUrl: string } };
+    const stateValue = new URL(payload.data.authorizeUrl).searchParams.get("state");
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("oauth/access_token")) return new Response(JSON.stringify({ access_token: "ephemeral-oauth-token" }));
+      if (url.endsWith("/user")) return new Response(JSON.stringify({ id: 7611727, login: "Sheshiyer" }));
+      if (url.includes("/user/installations?")) return new Response(JSON.stringify({ installations: [{ id: 42 }] }));
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+    const callback = await handleGithubCallback(
+      actorEnv,
+      new Request("https://worker.test/v1/github/callback"),
+      new URL(`https://worker.test/v1/github/callback?state=${encodeURIComponent(stateValue!)}&code=one-time-code`),
+    );
+    expect(callback.status).toBe(409);
+    await expect(callback.json()).resolves.toMatchObject({ error: { code: "github_actor_rebind_forbidden" } });
+    expect(fixture.actor()).toEqual(concurrentFounder);
+    expect(fixture.state()).toMatchObject({ status: "rejected" });
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps actor enrollment admin-only and rechecks active admin state", async () => {
+    const fixture = actorEnrollmentDb();
+    expect((await handleGithubActorEnrollStart(env(fixture.db), principal("employee"))).status).toBe(403);
+    const inactiveDb: D1DatabaseLike = {
+      prepare(sql: string) {
+        const statement = {
+          bind() { return statement; },
+          async first<T>() {
+            if (sql.includes("FROM plexus_identities")) return null;
+            return null;
+          },
+          async all<T>() { return { results: [] as T[] }; },
+          async run() { return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+    const response = await handleGithubActorEnrollStart(env(inactiveDb), principal("admin"));
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "github_forbidden" } });
+  });
+
+  it("revokes an enrolled actor when configured login and numeric ID no longer match", async () => {
+    const store = writeDb();
+    const revokedEnv = { ...env(store.db), TF_GITHUB_ALLOWED_ACTORS: "installer:88" };
+    const status = await handleGithubActor(revokedEnv, principal("admin"));
+    await expect(status.json()).resolves.toMatchObject({ data: { status: "forbidden", actor: { id: 77, login: "installer" } } });
+    const fetcher = vi.fn();
+    vi.stubGlobal("fetch", fetcher);
+    const response = await handleGithubPullRequest(revokedEnv, writeRequest(), "proj_test", principal("admin"));
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "github_actor_forbidden" } });
+    expect(fetcher).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
   });
 
   it("atomically consumes OAuth state and rejects a second code callback", async () => {
@@ -489,7 +734,8 @@ describe("GitHub App routes", () => {
           bind(...values: unknown[]) { args = values; return statement; },
           async first<T>() {
             if (sql.includes("FROM github_connection_states")) return ({ ...state } as T);
-            if (sql.includes("FROM github_installation_facts")) return ({ installation_id: Number(args[0]), installer_sender_id: 77, repository_selection: "selected", state: "active" } as T);
+            if (sql.includes("FROM github_installation_facts")) return ({ installation_id: Number(args[0]), installer_sender_id: 77, account_id: 8, account_login: "thoughtseed", account_type: "Organization", repository_selection: "selected", state: "active" } as T);
+            if (sql.includes("FROM github_workspace_actors")) return null;
             if (sql.includes("FROM plexus_identities")) return ({ id: "pid_admin" } as T);
             if (sql.includes("FROM github_workspace_installations")) return null;
             return null;
@@ -515,6 +761,16 @@ describe("GitHub App routes", () => {
     const inactiveAdmin = reconciliationDb("selected", false);
     await expect(reconcileBinding(env(inactiveAdmin.db), "nonce-hash")).rejects.toMatchObject({ code: "github_forbidden" });
     expect(inactiveAdmin.wasBound()).toBe(false);
+  });
+
+  it.each([
+    ["wrong organization ID", { id: 999, login: "thoughtseed", type: "Organization" }],
+    ["wrong organization login", { id: 8, login: "lookalike", type: "Organization" }],
+    ["personal account", { id: 8, login: "thoughtseed", type: "User" }],
+  ])("rejects installation binding for %s", async (_label, organization) => {
+    const fixture = reconciliationDb("selected", true, organization);
+    await expect(reconcileBinding(env(fixture.db), "nonce-hash")).rejects.toMatchObject({ code: "github_organization_forbidden" });
+    expect(fixture.wasBound()).toBe(false);
   });
 
   it.each([undefined, "unexpected"])("fails closed when signed repository_selection is %s", async (repositorySelection) => {
@@ -543,7 +799,7 @@ describe("GitHub App routes", () => {
           bind(...values: unknown[]) { args = values; return statement; },
           async first<T>() {
             if (sql.includes("FROM projects WHERE id")) return ({ id: args[0] } as T);
-            if (sql.includes("FROM github_workspace_installations b")) return ({ workspace_id: "ws_test", installation_id: 42, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected" } as T);
+            if (sql.includes("FROM github_workspace_installations b")) return ({ workspace_id: "ws_test", installation_id: 42, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
             if (sql.includes("FROM github_installation_repositories r")) return ({ installation_id: 42, repository_id: 101, owner_login: "thoughtseed", name: "private-repo", full_name: "thoughtseed/private-repo", is_private: 1, default_branch: "main", state: "active" } as T);
             return null;
           },
@@ -632,12 +888,12 @@ describe("GitHub App routes", () => {
 
   it("returns completed deterministic writes without duplicate GitHub mutation", async () => {
     const store = writeDb({ status: "completed", branch_name: "plexus/proj_test-existing", pull_request_number: 9, pull_request_url: "https://github.test/pulls/9", commit_sha: "c".repeat(40) });
-    const fetcher = vi.fn();
-    vi.stubGlobal("fetch", fetcher);
+    const github = guardedWriteFetch({ permission: "write", user: { id: 77, login: "installer" } });
+    vi.stubGlobal("fetch", github.fetcher);
     const response = await handleGithubPullRequest(env(store.db), writeRequest(), "proj_test", principal("admin"));
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toMatchObject({ data: { idempotent: true, branch: "plexus/proj_test-existing", pullRequest: { number: 9 } } });
-    expect(fetcher).not.toHaveBeenCalled();
+    expect(github.mutations).toHaveLength(0);
     expect(store.runs).toHaveLength(0);
     vi.unstubAllGlobals();
   });

--- a/cloudflare/worker/src/routes/github.ts
+++ b/cloudflare/worker/src/routes/github.ts
@@ -27,6 +27,33 @@ interface ConnectionStateRow {
   status: "pending_oauth" | "oauth_verified" | "bound" | "expired" | "rejected";
 }
 
+interface ActorConnectionStateRow {
+  nonce_hash: string;
+  workspace_id: string;
+  plexus_identity_id: string;
+  expires_at: number;
+  consumed_at: string | null;
+  oauth_user_id: number | null;
+  oauth_login: string | null;
+  status: "pending_oauth" | "bound" | "expired" | "rejected";
+}
+
+interface WorkspaceActorRow {
+  workspace_id: string;
+  plexus_identity_id: string;
+  github_user_id: number;
+  github_login: string;
+  verified_at: string;
+  verification_source: "installation" | "oauth";
+}
+
+interface GithubEnrollmentPolicy {
+  organization: string;
+  organizationId: number;
+  allowedActors: Array<{ id: number; login: string }>;
+  allowedActorByLogin: Map<string, number>;
+}
+
 interface InstallationBindingRow {
   workspace_id: string;
   installation_id: number;
@@ -118,7 +145,50 @@ function githubConfigurationPresent(env: Env): boolean {
     env.TF_GITHUB_APP_CALLBACK_URL,
     env.TF_GITHUB_APP_WEBHOOK_SECRET,
     env.TF_GITHUB_APP_STATE_SIGNING_SECRET,
+    env.TF_GITHUB_EXPECTED_ORG,
+    env.TF_GITHUB_EXPECTED_ORG_ID,
+    env.TF_GITHUB_ALLOWED_ACTORS,
   ].every((value) => Boolean(value?.trim()));
+}
+
+function githubEnrollmentPolicy(env: Env): GithubEnrollmentPolicy {
+  const organization = env.TF_GITHUB_EXPECTED_ORG?.trim() ?? "";
+  const organizationId = Number(env.TF_GITHUB_EXPECTED_ORG_ID);
+  const configuredActors = (env.TF_GITHUB_ALLOWED_ACTORS ?? "")
+    .split(",")
+    .map((actor) => actor.trim())
+    .filter(Boolean);
+  const validLogin = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+  const allowedActors = configuredActors.map((entry) => {
+    const separator = entry.lastIndexOf(":");
+    const login = separator > 0 ? entry.slice(0, separator).trim() : "";
+    const id = Number(separator > 0 ? entry.slice(separator + 1).trim() : "");
+    return { id, login };
+  });
+  const allowedActorByLogin = new Map(allowedActors.map((actor) => [actor.login.toLowerCase(), actor.id]));
+  const actorIds = new Set(allowedActors.map((actor) => actor.id));
+  if (!validLogin.test(organization) || !Number.isSafeInteger(organizationId) || organizationId <= 0 ||
+    allowedActors.length === 0 || allowedActors.some((actor) => !validLogin.test(actor.login) || !Number.isSafeInteger(actor.id) || actor.id <= 0) ||
+    allowedActorByLogin.size !== allowedActors.length || actorIds.size !== allowedActors.length) {
+    throw new GithubControlPlaneError("github_actor_policy_invalid", "GitHub organization and actor allowlist configuration is invalid.", 503);
+  }
+  return { organization, organizationId, allowedActors, allowedActorByLogin };
+}
+
+function isAllowedGithubActor(policy: GithubEnrollmentPolicy, user: { id: number; login: string }): boolean {
+  return policy.allowedActorByLogin.get(user.login.toLowerCase()) === user.id;
+}
+
+function assertAllowedGithubActor(policy: GithubEnrollmentPolicy, user: { id: number; login: string }): void {
+  if (!isAllowedGithubActor(policy, user)) {
+    throw new GithubControlPlaneError("github_actor_forbidden", "GitHub OAuth identity is not allowed for this workspace.", 403);
+  }
+}
+
+function assertExpectedOrganization(policy: GithubEnrollmentPolicy, binding: Pick<InstallationBindingRow, "account_id" | "account_login" | "account_type">): void {
+  if (binding.account_type !== "Organization" || binding.account_id !== policy.organizationId || binding.account_login?.toLowerCase() !== policy.organization.toLowerCase()) {
+    throw new GithubControlPlaneError("github_organization_forbidden", "GitHub App installation is not owned by the configured organization.", 403);
+  }
 }
 
 function requireAdmin(principal: PlexusPrincipal | null): Response | null {
@@ -159,13 +229,90 @@ async function getBinding(env: Env, workspaceId: string): Promise<InstallationBi
   );
 }
 
-async function assertActiveBinding(env: Env, principal: PlexusPrincipal): Promise<InstallationBindingRow> {
+async function assertActiveBinding(env: Env, principal: Pick<PlexusPrincipal, "workspaceId">): Promise<InstallationBindingRow> {
   const binding = await getBinding(env, principal.workspaceId);
   if (!binding) throw new GithubControlPlaneError("github_unconfigured", "No GitHub App installation is connected to this workspace.", 409);
   if (binding.repository_selection !== "selected") throw new GithubControlPlaneError("github_repository_selection_forbidden", "GitHub App access to all repositories is forbidden.", 403);
   if (binding.state === "suspended") throw new GithubControlPlaneError("github_suspended", "The workspace GitHub App installation is suspended.", 409);
   if (binding.state !== "active") throw new GithubControlPlaneError("github_forbidden", "The workspace GitHub App installation is revoked.", 403);
+  assertExpectedOrganization(githubEnrollmentPolicy(env), binding);
   return binding;
+}
+
+async function ensureActiveAdmin(env: Env, principal: Pick<PlexusPrincipal, "identityId" | "workspaceId">): Promise<void> {
+  const actor = await queryFirst<{ id: string }>(
+    database(env),
+    "SELECT id FROM plexus_identities WHERE id = ? AND workspace_id = ? AND role = 'admin' AND is_active = 1 LIMIT 1",
+    principal.identityId,
+    principal.workspaceId,
+  );
+  if (!actor) throw new GithubControlPlaneError("github_forbidden", "Current Plexus administrator access is required.", 403);
+}
+
+async function getWorkspaceActor(env: Env, workspaceId: string, identityId: string): Promise<WorkspaceActorRow | null> {
+  return queryFirst<WorkspaceActorRow>(
+    database(env),
+    "SELECT * FROM github_workspace_actors WHERE workspace_id = ? AND plexus_identity_id = ? LIMIT 1",
+    workspaceId,
+    identityId,
+  );
+}
+
+async function upsertWorkspaceActor(
+  env: Env,
+  input: {
+    workspaceId: string;
+    identityId: string;
+    githubUserId: number;
+    githubLogin: string;
+    source: "installation" | "oauth";
+    nonceHash: string | null;
+  },
+): Promise<void> {
+  if (!Number.isSafeInteger(input.githubUserId) || input.githubUserId <= 0 || !input.githubLogin) {
+    throw new GithubControlPlaneError("github_oauth_identity_failed", "GitHub OAuth identity is invalid.", 502);
+  }
+  const existingActor = await getWorkspaceActor(env, input.workspaceId, input.identityId);
+  if (existingActor && existingActor.github_user_id !== input.githubUserId) {
+    throw new GithubControlPlaneError("github_actor_rebind_forbidden", "Plexus identity is already bound to a different numeric GitHub identity.", 409);
+  }
+  const conflict = await queryFirst<{ plexus_identity_id: string }>(
+    database(env),
+    `SELECT plexus_identity_id FROM github_workspace_actors
+      WHERE workspace_id = ? AND github_user_id = ? AND plexus_identity_id <> ? LIMIT 1`,
+    input.workspaceId,
+    input.githubUserId,
+    input.identityId,
+  );
+  if (conflict) throw new GithubControlPlaneError("github_actor_already_bound", "GitHub identity is already bound to another Plexus identity in this workspace.", 409);
+  const timestamp = now();
+  const changes = await executeChanges(
+    database(env),
+    `INSERT INTO github_workspace_actors
+       (workspace_id, plexus_identity_id, github_user_id, github_login, verified_at,
+        verification_source, connection_nonce_hash, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(workspace_id, plexus_identity_id) DO UPDATE SET
+       github_user_id = excluded.github_user_id,
+       github_login = excluded.github_login,
+       verified_at = excluded.verified_at,
+       verification_source = excluded.verification_source,
+       connection_nonce_hash = excluded.connection_nonce_hash,
+       updated_at = excluded.updated_at
+     WHERE github_workspace_actors.github_user_id = excluded.github_user_id`,
+    input.workspaceId,
+    input.identityId,
+    input.githubUserId,
+    input.githubLogin,
+    timestamp,
+    input.source,
+    input.nonceHash,
+    timestamp,
+    timestamp,
+  );
+  if (changes !== 1) {
+    throw new GithubControlPlaneError("github_actor_rebind_forbidden", "Plexus identity is already bound to a different numeric GitHub identity.", 409);
+  }
 }
 
 export async function reconcileBinding(env: Env, nonceHash: string): Promise<boolean> {
@@ -173,9 +320,17 @@ export async function reconcileBinding(env: Env, nonceHash: string): Promise<boo
   const state = await queryFirst<ConnectionStateRow>(db, "SELECT * FROM github_connection_states WHERE nonce_hash = ? LIMIT 1", nonceHash);
   if (!state?.oauth_user_id || !state.oauth_login || !state.untrusted_installation_id || state.status === "rejected" || state.status === "expired") return false;
   await ensureCallbackActorStillAdmin(env, { workspace: state.workspace_id, actor: state.plexus_actor_id });
-  const fact = await queryFirst<{ installation_id: number; installer_sender_id: number; repository_selection: string; state: string }>(
+  const fact = await queryFirst<{
+    installation_id: number;
+    installer_sender_id: number;
+    account_id: number;
+    account_login: string;
+    account_type: string;
+    repository_selection: string;
+    state: string;
+  }>(
     db,
-    "SELECT installation_id, installer_sender_id, repository_selection, state FROM github_installation_facts WHERE installation_id = ? LIMIT 1",
+    "SELECT installation_id, installer_sender_id, account_id, account_login, account_type, repository_selection, state FROM github_installation_facts WHERE installation_id = ? LIMIT 1",
     state.untrusted_installation_id,
   );
   if (!fact || fact.state === "deleted") return false;
@@ -187,6 +342,14 @@ export async function reconcileBinding(env: Env, nonceHash: string): Promise<boo
     await execute(db, "UPDATE github_connection_states SET status = 'rejected', updated_at = ? WHERE nonce_hash = ?", now(), nonceHash);
     throw new GithubControlPlaneError("github_actor_mismatch", "OAuth actor does not match the signed installation webhook sender.", 403);
   }
+  const policy = githubEnrollmentPolicy(env);
+  try {
+    assertExpectedOrganization(policy, fact);
+    assertAllowedGithubActor(policy, { id: state.oauth_user_id, login: state.oauth_login });
+  } catch (error) {
+    await execute(db, "UPDATE github_connection_states SET status = 'rejected', updated_at = ? WHERE nonce_hash = ?", now(), nonceHash);
+    throw error;
+  }
   const otherWorkspace = await queryFirst<{ workspace_id: string }>(
     db,
     "SELECT workspace_id FROM github_workspace_installations WHERE installation_id = ? AND workspace_id <> ? LIMIT 1",
@@ -194,6 +357,14 @@ export async function reconcileBinding(env: Env, nonceHash: string): Promise<boo
     state.workspace_id,
   );
   if (otherWorkspace) throw new GithubControlPlaneError("github_installation_already_bound", "This GitHub App installation is already bound to another workspace.", 409);
+  await upsertWorkspaceActor(env, {
+    workspaceId: state.workspace_id,
+    identityId: state.plexus_actor_id,
+    githubUserId: state.oauth_user_id,
+    githubLogin: state.oauth_login,
+    source: "installation",
+    nonceHash: null,
+  });
   const timestamp = now();
   await execute(
     db,
@@ -232,7 +403,14 @@ export async function handleGithubConnection(env: Env, principal: PlexusPrincipa
     }
     const binding = await getBinding(env, principal!.workspaceId);
     if (binding) {
-      const status = binding.repository_selection !== "selected"
+      let expectedOrganization = true;
+      try {
+        assertExpectedOrganization(githubEnrollmentPolicy(env), binding);
+      } catch (error) {
+        if (error instanceof GithubControlPlaneError) expectedOrganization = false;
+        else throw error;
+      }
+      const status = !expectedOrganization || binding.repository_selection !== "selected"
         ? "forbidden"
         : binding.state === "active" ? "connected" : binding.state === "suspended" ? "suspended" : "forbidden";
       return jsonOk({ status, installationId: binding.installation_id, account: { id: binding.account_id, login: binding.account_login, type: binding.account_type } });
@@ -285,6 +463,93 @@ export async function handleGithubConnectStart(env: Env, principal: PlexusPrinci
   }
 }
 
+function actorPolicyPayload(policy: GithubEnrollmentPolicy) {
+  return {
+    organization: { id: policy.organizationId, login: policy.organization },
+    allowedLogins: policy.allowedActors.map((actor) => actor.login),
+  };
+}
+
+export async function handleGithubActor(env: Env, principal: PlexusPrincipal | null): Promise<Response> {
+  const denied = requirePrincipal(principal);
+  if (denied) return denied;
+  try {
+    if (!githubConfigurationPresent(env)) return jsonOk({ status: "unconfigured" as const });
+    const policy = githubEnrollmentPolicy(env);
+    const policyPayload = actorPolicyPayload(policy);
+    const binding = await getBinding(env, principal!.workspaceId);
+    if (!binding) return jsonOk({ status: "unconfigured" as const, ...policyPayload });
+    if (binding.repository_selection !== "selected" || binding.state !== "active") {
+      return jsonOk({ status: "forbidden" as const, ...policyPayload });
+    }
+    try {
+      assertExpectedOrganization(policy, binding);
+    } catch (error) {
+      if (error instanceof GithubControlPlaneError) return jsonOk({ status: "forbidden" as const, ...policyPayload });
+      throw error;
+    }
+    const actor = await getWorkspaceActor(env, principal!.workspaceId, principal!.identityId);
+    if (actor) {
+      const actorPayload = { id: actor.github_user_id, login: actor.github_login, verifiedAt: actor.verified_at };
+      return jsonOk({
+        status: isAllowedGithubActor(policy, { id: actor.github_user_id, login: actor.github_login }) ? "verified" as const : "forbidden" as const,
+        ...policyPayload,
+        actor: actorPayload,
+      });
+    }
+    const pending = await queryFirst<{ expires_at: number }>(
+      database(env),
+      `SELECT expires_at FROM github_actor_connection_states
+        WHERE workspace_id = ? AND plexus_identity_id = ? AND status = 'pending_oauth' AND expires_at > ?
+        ORDER BY created_at DESC LIMIT 1`,
+      principal!.workspaceId,
+      principal!.identityId,
+      Math.floor(Date.now() / 1000),
+    );
+    return jsonOk({ status: pending ? "pending" as const : "not_enrolled" as const, ...policyPayload });
+  } catch (error) {
+    return controlPlaneError(error);
+  }
+}
+
+export async function handleGithubActorEnrollStart(env: Env, principal: PlexusPrincipal | null): Promise<Response> {
+  const denied = requireAdmin(principal);
+  if (denied) return denied;
+  try {
+    await ensureActiveAdmin(env, principal!);
+    await assertActiveBinding(env, principal!);
+    const policy = githubEnrollmentPolicy(env);
+    const nonce = randomNonce();
+    const nonceHash = await sha256Hex(nonce);
+    const expiresAt = Math.floor(Date.now() / 1000) + 600;
+    const state = await signConnectState({ workspace: principal!.workspaceId, actor: principal!.identityId, nonce, exp: expiresAt }, stateSecret(env));
+    const timestamp = now();
+    await execute(
+      database(env),
+      `UPDATE github_actor_connection_states SET status = 'rejected', updated_at = ?
+        WHERE workspace_id = ? AND plexus_identity_id = ? AND status = 'pending_oauth'`,
+      timestamp,
+      principal!.workspaceId,
+      principal!.identityId,
+    );
+    await execute(
+      database(env),
+      `INSERT INTO github_actor_connection_states
+       (nonce_hash, workspace_id, plexus_identity_id, expires_at, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'pending_oauth', ?, ?)`,
+      nonceHash,
+      principal!.workspaceId,
+      principal!.identityId,
+      expiresAt,
+      timestamp,
+      timestamp,
+    );
+    return jsonOk({ status: "pending" as const, authorizeUrl: buildOauthAuthorizeUrl(env, state), ...actorPolicyPayload(policy) }, { status: 201 });
+  } catch (error) {
+    return controlPlaneError(error);
+  }
+}
+
 async function ensureCallbackActorStillAdmin(env: Env, state: { workspace: string; actor: string }): Promise<void> {
   const actor = await queryFirst<{ id: string }>(
     database(env),
@@ -295,6 +560,62 @@ async function ensureCallbackActorStillAdmin(env: Env, state: { workspace: strin
   if (!actor) throw new GithubControlPlaneError("github_forbidden", "The initiating Plexus administrator is no longer active in this workspace.", 403);
 }
 
+async function handleGithubActorCallback(
+  env: Env,
+  url: URL,
+  state: { workspace: string; actor: string },
+  nonceHash: string,
+): Promise<Response> {
+  if (url.searchParams.has("installation_id")) {
+    throw new GithubControlPlaneError("github_actor_callback_invalid", "Actor enrollment cannot bind or replace a GitHub App installation.", 400);
+  }
+  const code = url.searchParams.get("code");
+  if (!code) throw new GithubControlPlaneError("github_callback_invalid", "OAuth code is required for GitHub actor enrollment.", 400);
+  const claimedAt = now();
+  const changes = await executeChanges(
+    database(env),
+    `UPDATE github_actor_connection_states SET consumed_at = ?, updated_at = ?
+      WHERE nonce_hash = ? AND workspace_id = ? AND plexus_identity_id = ?
+        AND consumed_at IS NULL AND expires_at > ? AND status = 'pending_oauth'`,
+    claimedAt,
+    claimedAt,
+    nonceHash,
+    state.workspace,
+    state.actor,
+    Math.floor(Date.now() / 1000),
+  );
+  if (changes !== 1) throw new GithubControlPlaneError("github_state_consumed", "GitHub actor enrollment state was already consumed.", 409);
+  try {
+    const policy = githubEnrollmentPolicy(env);
+    const binding = await assertActiveBinding(env, { workspaceId: state.workspace });
+    const user = await new GithubAppClient(env).exchangeOauthCode(code, binding.installation_id);
+    assertAllowedGithubActor(policy, user);
+    await upsertWorkspaceActor(env, {
+      workspaceId: state.workspace,
+      identityId: state.actor,
+      githubUserId: user.id,
+      githubLogin: user.login,
+      source: "oauth",
+      nonceHash,
+    });
+    const timestamp = now();
+    await execute(
+      database(env),
+      `UPDATE github_actor_connection_states
+          SET oauth_user_id = ?, oauth_login = ?, status = 'bound', updated_at = ?
+        WHERE nonce_hash = ?`,
+      user.id,
+      user.login,
+      timestamp,
+      nonceHash,
+    );
+    return jsonOk({ status: "verified" as const, actor: { id: user.id, login: user.login, verifiedAt: timestamp } });
+  } catch (error) {
+    await execute(database(env), "UPDATE github_actor_connection_states SET status = 'rejected', updated_at = ? WHERE nonce_hash = ?", now(), nonceHash);
+    throw error;
+  }
+}
+
 export async function handleGithubCallback(env: Env, _request: Request, url: URL): Promise<Response> {
   try {
     const stateValue = url.searchParams.get("state") ?? "";
@@ -302,6 +623,12 @@ export async function handleGithubCallback(env: Env, _request: Request, url: URL
     await ensureCallbackActorStillAdmin(env, state);
     const nonceHash = await sha256Hex(state.nonce);
     const db = database(env);
+    const actorState = await queryFirst<ActorConnectionStateRow>(
+      db,
+      "SELECT * FROM github_actor_connection_states WHERE nonce_hash = ? LIMIT 1",
+      nonceHash,
+    );
+    if (actorState) return await handleGithubActorCallback(env, url, state, nonceHash);
     const installationParam = url.searchParams.get("installation_id");
     const installationId = installationParam && /^\d+$/.test(installationParam) ? Number(installationParam) : null;
     if (installationParam && (!installationId || !Number.isSafeInteger(installationId))) {
@@ -343,7 +670,9 @@ export async function handleGithubCallback(env: Env, _request: Request, url: URL
       );
       if (changes === 1) {
         try {
+          const policy = githubEnrollmentPolicy(env);
           const user = await new GithubAppClient(env).exchangeOauthCode(code);
+          assertAllowedGithubActor(policy, user);
           await execute(
             db,
             `UPDATE github_connection_states
@@ -953,23 +1282,26 @@ export async function handleGithubPullRequest(env: Env, request: Request, projec
     }
     const files = validateWriteFiles(body.files);
     await assertProjectWorkspace(env, projectId, principal!.workspaceId);
+    await ensureActiveAdmin(env, principal!);
     const binding = await assertActiveBinding(env, principal!);
-    if (binding.connected_by_identity_id !== principal!.identityId) throw new GithubControlPlaneError("github_actor_not_verified", "Current Plexus administrator has not verified this GitHub identity.", 403);
+    const actor = await getWorkspaceActor(env, principal!.workspaceId, principal!.identityId);
+    if (!actor) throw new GithubControlPlaneError("github_actor_not_verified", "Current Plexus administrator has not verified a GitHub identity.", 403);
+    assertAllowedGithubActor(githubEnrollmentPolicy(env), { id: actor.github_user_id, login: actor.github_login });
     const verified = await getVerifiedRepository(env, projectId, principal!.workspaceId);
     if (verified.repository_id !== repositoryId || verified.installation_id !== binding.installation_id) throw new GithubControlPlaneError("github_repository_forbidden", "Repository is not the verified project repository.", 403);
     const operationKey = await sha256Hex(JSON.stringify({ workspace: principal!.workspaceId, actor: principal!.identityId, projectId, repositoryId, baseSha, title, pullBody, commitMessage: requestedCommitMessage, files }));
     const branch = `plexus/${safeBranchPart(projectId)}-${operationKey.slice(0, 12)}`;
     if (branch === verified.default_branch) throw new GithubControlPlaneError("github_default_branch_forbidden", "Default branch writes are forbidden.", 403);
+    const client = new GithubAppClient(env);
+    const token = await client.createInstallationToken(binding.installation_id, [repositoryId], "write");
+    if (!(await client.hasWritePermission(token.token, verified.owner_login, verified.name, actor.github_login, actor.github_user_id))) {
+      throw new GithubControlPlaneError("github_membership_forbidden", "Verified GitHub actor no longer has write, maintain, or admin permission.", 403);
+    }
     const existing = await queryFirst<{ status: string; branch_name: string; pull_request_number: number | null; pull_request_url: string | null; commit_sha: string | null }>(database(env), "SELECT status, branch_name, pull_request_number, pull_request_url, commit_sha FROM github_write_operations WHERE operation_key = ? LIMIT 1", operationKey);
     if (existing?.status === "completed") return jsonOk({ status: "created" as const, idempotent: true, branch: existing.branch_name, commitSha: existing.commit_sha, pullRequest: { number: existing.pull_request_number, url: existing.pull_request_url } });
     if (existing && existing.status !== "failed") throw new GithubControlPlaneError("github_write_in_progress", "An identical guarded write is already in progress.", 409, true);
-    const client = new GithubAppClient(env);
     let operationTracked = Boolean(existing);
     try {
-      const token = await client.createInstallationToken(binding.installation_id, [repositoryId], "write");
-      if (!(await client.hasWritePermission(token.token, verified.owner_login, verified.name, binding.verified_github_login, binding.verified_github_user_id))) {
-        throw new GithubControlPlaneError("github_membership_forbidden", "Verified GitHub actor no longer has write, maintain, or admin permission.", 403);
-      }
       const repoPath = `/repos/${encodeURIComponent(verified.owner_login)}/${encodeURIComponent(verified.name)}`;
       const repo = await client.request<GithubRepository>(token.token, repoPath);
       if (repo.id !== repositoryId || repo.default_branch !== verified.default_branch) throw new GithubControlPlaneError("github_repository_changed", "Repository identity or default branch changed; verify it again.", 409);

--- a/cloudflare/worker/src/routes/v1.ts
+++ b/cloudflare/worker/src/routes/v1.ts
@@ -79,6 +79,8 @@ import { handleGetTeamSnapshot, handlePostTeamRefresh } from "./team";
 import { queryFirst, queryAll } from "../lib/db";
 import {
   handleGithubActivitySync,
+  handleGithubActor,
+  handleGithubActorEnrollStart,
   handleGithubCallback,
   handleGithubConnection,
   handleGithubConnectStart,
@@ -212,6 +214,12 @@ export async function handleV1Request(request: Request, env: Env, url: URL): Pro
   }
   if (method === "POST" && pathname === "/v1/github/connect/start") {
     return handleGithubConnectStart(env, plexusPrincipal);
+  }
+  if (method === "GET" && pathname === "/v1/github/actor") {
+    return handleGithubActor(env, plexusPrincipal);
+  }
+  if (method === "POST" && pathname === "/v1/github/actor/enroll/start") {
+    return handleGithubActorEnrollStart(env, plexusPrincipal);
   }
   if (method === "GET" && pathname === "/v1/github/repositories") {
     return handleGithubRepositories(env, plexusPrincipal);

--- a/cloudflare/worker/wrangler.jsonc
+++ b/cloudflare/worker/wrangler.jsonc
@@ -18,6 +18,9 @@
     // use `wrangler rollback`, set them to "", or delete in the dashboard.
     "TF_ACCESS_TEAM_DOMAIN": "red-queen-4dfa.cloudflareaccess.com",
     "TF_ACCESS_AUD": "5695e8409cd4e838eaaef4de4995541dae4f31a2773945ea67f136800977c200,d3892b5d2a62027029b09b2fd015a9e8074d5efb38c443099f803517cb3feb51",
+    "TF_GITHUB_EXPECTED_ORG": "thoughtseed-labs",
+    "TF_GITHUB_EXPECTED_ORG_ID": "65741640",
+    "TF_GITHUB_ALLOWED_ACTORS": "Sheshiyer:7611727,psychon7:47470954",
     "TF_INTEGRATION_CONFIG_JSON": "{\"github\":{\"repos\":[{\"repo\":\"Sheshiyer/parkarea-aleph\",\"displayName\":\"ParkArea Phase 2 - Germany Launch\",\"clientName\":\"ParkArea\",\"defaultMilestoneNumber\":1,\"enabled\":true}]},\"huly\":{\"mirrorMode\":\"read_only\",\"mirrorEnabled\":true},\"slack\":{},\"clockify\":{}}",
     // Temporary internal shared secret for m2m (parity, Hermes) bypassing CF Access service token issues on this Worker route.
     // Set a long random value. Callers send header X-TeamForge-Internal-Secret.


### PR DESCRIPTION
## Summary
- add per-workspace, per-Plexus-admin GitHub actor enrollment with signed single-use OAuth state
- pin thoughtseed-labs `65741640`, Sheshiyer `7611727`, and psychon7 `47470954`
- prove the OAuth actor can access the exact bound GitHub App installation using an ephemeral user token
- backfill the verified installation connector through migration 0013
- authorize writes through the current actor mapping plus live numeric repository permission

## Guardrails
- OAuth tokens are used only for `/user` and `/user/installations`, then discarded
- installation must match selected-repositories-only and the pinned organization login/type/id
- active Plexus admin state is rechecked at enrollment and write time
- policy removal revokes writes immediately
- cross-founder rebinding is rejected with an atomic compare-and-set
- default-branch, workflow-file, base-SHA, numeric-repository, size, and idempotency protections remain intact

## Verification
- `pnpm check`
- `pnpm test` (12 files, 117 tests)
- focused GitHub route suite (36 tests)
- migrations 0001 through 0013 applied to a fresh SQLite database
- `git diff --check`

## Deployment boundary
Source only. Production requires migration 0013 and Worker deployment before the companion Plexus OTA release.
