### PR TITLE
feat(github): support exact multi-owner installations

### DIFF
--- a/cloudflare/worker/README.md
+++ b/cloudflare/worker/README.md
@@ -130,9 +130,11 @@ Example `TF_INTEGRATION_CONFIG_JSON`:
 }
 ```
 
-## Private GitHub App control plane
+## GitHub App control plane
 
-Private repository authority uses a GitHub App. The new path never reads
+Private repository authority uses one public, unlisted GitHub App so the same
+App can be installed on the Thoughtseed Labs organization and the founders'
+personal accounts. The path never reads
 `TF_GITHUB_TOKEN_GLOBAL`; that variable remains only for legacy sync behavior
 outside this control plane. App and installation tokens are held in Worker
 memory only, scoped to numeric repository IDs whenever the repository is
@@ -144,8 +146,9 @@ Configure the non-secret values as Worker variables:
 - `TF_GITHUB_APP_SLUG`
 - `TF_GITHUB_APP_CLIENT_ID`
 - `TF_GITHUB_APP_CALLBACK_URL` (`https://<worker>/v1/github/callback`)
-- `TF_GITHUB_EXPECTED_ORG` (`thoughtseed-labs`)
-- `TF_GITHUB_EXPECTED_ORG_ID` (`65741640`)
+- `TF_GITHUB_ALLOWED_INSTALLATION_ACCOUNTS`
+  (`Organization:thoughtseed-labs:65741640,User:Sheshiyer:7611727,User:psychon7:47470954`;
+  exact `Type:login:numeric-account-id` entries)
 - `TF_GITHUB_ALLOWED_ACTORS`
   (`Sheshiyer:7611727,psychon7:47470954`; `login:numeric-user-id` pairs)
 
@@ -167,16 +170,18 @@ same-workspace project.
 
 Each founder enrolls separately through GitHub App OAuth. During actor
 enrollment, the Worker uses the ephemeral GitHub user access token only for
-`GET /user` and `GET /user/installations`, requires access to the workspace's
-already-bound installation ID, and then discards the token. D1 stores only the
+`GET /user` and `GET /user/installations`, requires access to any active
+installation already bound to the workspace, and then discards the token. D1 stores only the
 verified numeric GitHub user ID, login snapshot, and Plexus identity mapping.
 Login text is never sufficient authority: the configured login and immutable
 numeric user ID must both match.
 
 Subscribe the App to the `installation` and `installation_repositories`
-webhook events. During installation, choose **Only select repositories** and
-select the approved pilot repositories. The Worker rejects the GitHub
-`repository_selection: all` grant and will not bind that installation.
+webhook events. Install it separately on each approved account, choose **Only
+select repositories**, and select only that account's approved repositories.
+The Worker rejects the GitHub `repository_selection: all` grant and ignores
+signed public-App webhooks from non-allowlisted accounts before persisting
+installation or repository facts.
 
 Required GitHub App repository permissions are:
 
@@ -196,7 +201,7 @@ branch, force references, or modify `.github/workflows`.
 Routes:
 
 - `GET /v1/github/connection`
-- `POST /v1/github/connect/start`
+- `POST /v1/github/connect/start` (`{ "accountId": <numeric allowlisted ID> }`)
 - `GET /v1/github/actor`
 - `POST /v1/github/actor/enroll/start`
 - `GET /v1/github/repositories`
@@ -206,19 +211,23 @@ Routes:
 - `GET /v1/github/callback` (public, signed single-use state)
 - `POST /v1/github/webhook` (public, `X-Hub-Signature-256`)
 
-Apply migrations `0012_github_app_control_plane.sql` and
-`0013_github_workspace_actors.sql` before enabling the routes.
+Apply migrations `0012_github_app_control_plane.sql`,
+`0013_github_workspace_actors.sql`, and
+`0014_github_multi_owner_installations.sql` before enabling the routes.
 It stores OAuth/install correlation state, immutable signed installation
-facts, workspace bindings, numeric repositories, delivery dedupe/leases,
-project verification, and idempotent write receipts. It stores no OAuth token,
-installation token, client secret, webhook secret, or private key.
+facts, multiple exact account-scoped workspace bindings, numeric repositories,
+delivery dedupe/leases, project verification, and idempotent write receipts.
+Repository verification requires numeric `installationId` and `repositoryId`;
+activity and writes use the project's persisted installation. It stores no
+OAuth token, installation token, client secret, webhook secret, private key,
+or PAT.
 
 Immediate founder revocation is fail-closed: remove the founder's
 `login:numeric-id` pair from `TF_GITHUB_ALLOWED_ACTORS` or revoke their active
 Plexus administrator role. Every guarded write rechecks both controls and then
 rechecks the actor's live numeric repository permission before mutation. A
 local organization-membership preflight is setup guidance only; server
-authority is the pinned founder IDs, pinned bound organization installation,
+authority is the pinned founder IDs, exact allowlisted installation accounts,
 active Plexus admin, and live per-repository permission.
 
 ### Founder inputs before setup

--- a/cloudflare/worker/migrations/0014_github_multi_owner_installations.sql
+++ b/cloudflare/worker/migrations/0014_github_multi_owner_installations.sql
@@ -51,4 +51,3 @@ DROP TABLE github_workspace_installations_0013;
 
 CREATE INDEX idx_github_workspace_installations_workspace_state
   ON github_workspace_installations(workspace_id, state, account_id);
-

--- a/cloudflare/worker/migrations/0014_github_multi_owner_installations.sql
+++ b/cloudflare/worker/migrations/0014_github_multi_owner_installations.sql
@@ -1,0 +1,54 @@
+-- Allow one Plexus workspace to bind one exact GitHub App installation per
+-- allowlisted account. Existing 0012/0013 bindings are preserved by deriving
+-- their immutable account ID from the signed installation fact.
+
+ALTER TABLE github_connection_states ADD COLUMN target_account_id INTEGER;
+ALTER TABLE github_connection_states ADD COLUMN target_account_login TEXT;
+ALTER TABLE github_connection_states ADD COLUMN target_account_type TEXT;
+
+ALTER TABLE github_workspace_installations RENAME TO github_workspace_installations_0013;
+
+CREATE TABLE github_workspace_installations (
+  workspace_id TEXT NOT NULL,
+  installation_id INTEGER NOT NULL UNIQUE,
+  account_id INTEGER NOT NULL,
+  connected_by_identity_id TEXT NOT NULL,
+  verified_github_user_id INTEGER NOT NULL,
+  verified_github_login TEXT NOT NULL,
+  connection_nonce_hash TEXT NOT NULL UNIQUE,
+  state TEXT NOT NULL DEFAULT 'active' CHECK (state IN ('active', 'suspended', 'revoked')),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (workspace_id, installation_id),
+  UNIQUE (workspace_id, account_id),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE,
+  FOREIGN KEY (installation_id) REFERENCES github_installation_facts(installation_id) ON DELETE CASCADE,
+  FOREIGN KEY (connected_by_identity_id) REFERENCES plexus_identities(id) ON DELETE CASCADE,
+  FOREIGN KEY (connection_nonce_hash) REFERENCES github_connection_states(nonce_hash) ON DELETE RESTRICT
+);
+
+INSERT INTO github_workspace_installations (
+  workspace_id, installation_id, account_id, connected_by_identity_id,
+  verified_github_user_id, verified_github_login, connection_nonce_hash,
+  state, created_at, updated_at
+)
+SELECT
+  prior.workspace_id,
+  prior.installation_id,
+  facts.account_id,
+  prior.connected_by_identity_id,
+  prior.verified_github_user_id,
+  prior.verified_github_login,
+  prior.connection_nonce_hash,
+  prior.state,
+  prior.created_at,
+  prior.updated_at
+FROM github_workspace_installations_0013 AS prior
+JOIN github_installation_facts AS facts
+  ON facts.installation_id = prior.installation_id;
+
+DROP TABLE github_workspace_installations_0013;
+
+CREATE INDEX idx_github_workspace_installations_workspace_state
+  ON github_workspace_installations(workspace_id, state, account_id);
+

--- a/cloudflare/worker/src/lib/env.ts
+++ b/cloudflare/worker/src/lib/env.ts
@@ -63,10 +63,10 @@ export interface Env {
   TF_GITHUB_APP_CALLBACK_URL?: string;
   TF_GITHUB_APP_WEBHOOK_SECRET?: string;
   TF_GITHUB_APP_STATE_SIGNING_SECRET?: string;
-  // Non-secret enrollment policy. Login names are hints/gates at OAuth time;
-  // durable actor authority is always the verified numeric GitHub user ID.
-  TF_GITHUB_EXPECTED_ORG?: string;
-  TF_GITHUB_EXPECTED_ORG_ID?: string;
+  // Non-secret installation and actor policies. Account entries are
+  // Type:login:numeric-id; actor entries are login:numeric-user-id.
+  // Durable authority always includes the immutable numeric GitHub ID.
+  TF_GITHUB_ALLOWED_INSTALLATION_ACCOUNTS?: string;
   TF_GITHUB_ALLOWED_ACTORS?: string;
   TF_INTEGRATION_CONFIG_JSON?: string;
   TF_CREDENTIAL_ENVELOPE_KEY?: string;

--- a/cloudflare/worker/src/lib/github-app.ts
+++ b/cloudflare/worker/src/lib/github-app.ts
@@ -10,6 +10,13 @@ export interface GithubConnectState {
   actor: string;
   nonce: string;
   exp: number;
+  target?: GithubInstallationAccountTarget;
+}
+
+export interface GithubInstallationAccountTarget {
+  id: number;
+  login: string;
+  type: "Organization" | "User";
 }
 
 export interface GithubUser {
@@ -145,7 +152,13 @@ export async function verifyConnectState(value: string, secret: string, nowSecon
   }
   const state = parsed as Partial<GithubConnectState>;
   const keys = Object.keys(state).sort().join(",");
-  if (keys !== "actor,exp,nonce,workspace" || !state.workspace || !state.actor || !state.nonce || !Number.isInteger(state.exp)) {
+  const target = state.target as Partial<GithubInstallationAccountTarget> | undefined;
+  const targetKeys = target ? Object.keys(target).sort().join(",") : "";
+  const baseValid = (keys === "actor,exp,nonce,workspace" || keys === "actor,exp,nonce,target,workspace") &&
+    Boolean(state.workspace && state.actor && state.nonce && Number.isInteger(state.exp));
+  const targetValid = !target || (targetKeys === "id,login,type" && Number.isSafeInteger(target.id) && (target.id ?? 0) > 0 &&
+    typeof target.login === "string" && Boolean(target.login) && (target.type === "Organization" || target.type === "User"));
+  if (!baseValid || !targetValid) {
     throw new GithubControlPlaneError("github_state_invalid", "GitHub connection state fields are invalid.", 400);
   }
   if ((state.exp as number) <= nowSeconds) throw new GithubControlPlaneError("github_state_expired", "GitHub connection state has expired.", 410);
@@ -245,7 +258,7 @@ export class GithubAppClient {
     return `${signingInput}.${bytesToBase64Url(signature)}`;
   }
 
-  async exchangeOauthCode(code: string, requiredInstallationId?: number): Promise<GithubUser> {
+  async exchangeOauthCode(code: string, requiredInstallationIds?: number[]): Promise<GithubUser> {
     const config = requireGithubAppEnv(this.env);
     const tokenResponse = await this.fetchImpl("https://github.com/login/oauth/access_token", {
       method: "POST",
@@ -264,9 +277,10 @@ export class GithubAppClient {
     });
     const user = await responseJson<Pick<GithubUser, "id" | "login">>(userResponse, "github_oauth_identity_failed");
     if (!Number.isSafeInteger(user.id) || !user.login) throw new GithubControlPlaneError("github_oauth_identity_failed", "GitHub OAuth identity is invalid.", 502);
-    if (requiredInstallationId !== undefined) {
-      if (!Number.isSafeInteger(requiredInstallationId) || requiredInstallationId <= 0) {
-        throw new GithubControlPlaneError("github_installation_hint_invalid", "Installation ID must be numeric.", 400);
+    if (requiredInstallationIds !== undefined) {
+      const required = new Set(requiredInstallationIds);
+      if (required.size === 0 || [...required].some((installationId) => !Number.isSafeInteger(installationId) || installationId <= 0)) {
+        throw new GithubControlPlaneError("github_installation_hint_invalid", "Installation IDs must be positive integers.", 400);
       }
       let installationAccessible = false;
       for (let page = 1; page <= 10; page += 1) {
@@ -280,14 +294,14 @@ export class GithubAppClient {
         if (!Array.isArray(installations.installations)) {
           throw new GithubControlPlaneError("github_oauth_installations_failed", "GitHub App installation authority is invalid.", 502);
         }
-        if (installations.installations.some((installation) => installation.id === requiredInstallationId)) {
+        if (installations.installations.some((installation) => installation.id !== undefined && required.has(installation.id))) {
           installationAccessible = true;
           break;
         }
         if (installations.installations.length < 100) break;
       }
       if (!installationAccessible) {
-        throw new GithubControlPlaneError("github_oauth_installation_forbidden", "GitHub OAuth identity cannot access the workspace installation.", 403);
+        throw new GithubControlPlaneError("github_oauth_installation_forbidden", "GitHub OAuth identity cannot access any active workspace installation.", 403);
       }
     }
     return { id: user.id, login: user.login };

--- a/cloudflare/worker/src/routes/__tests__/github-migration.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/github-migration.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("GitHub multi-installation migration", () => {
+  it("preserves prior bindings while enforcing workspace and account uniqueness", () => {
+    const sql = readFileSync(new URL("../../../migrations/0014_github_multi_owner_installations.sql", import.meta.url), "utf8");
+    expect(sql).toContain("INSERT INTO github_workspace_installations");
+    expect(sql).toContain("SELECT");
+    expect(sql).toMatch(/PRIMARY KEY\s*\(workspace_id,\s*installation_id\)/i);
+    expect(sql).toMatch(/installation_id\s+INTEGER\s+NOT NULL\s+UNIQUE/i);
+    expect(sql).toMatch(/UNIQUE\s*\(workspace_id,\s*account_id\)/i);
+    expect(sql).toMatch(/connection_nonce_hash\s+TEXT\s+NOT NULL\s+UNIQUE/i);
+    expect(sql).toContain("target_account_id");
+    expect(sql).toContain("target_account_login");
+    expect(sql).toContain("target_account_type");
+  });
+});

--- a/cloudflare/worker/src/routes/__tests__/github-migration.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/github-migration.test.ts
@@ -1,17 +1,151 @@
 import { readFileSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 
 describe("GitHub multi-installation migration", () => {
-  it("preserves prior bindings while enforcing workspace and account uniqueness", () => {
-    const sql = readFileSync(new URL("../../../migrations/0014_github_multi_owner_installations.sql", import.meta.url), "utf8");
-    expect(sql).toContain("INSERT INTO github_workspace_installations");
-    expect(sql).toContain("SELECT");
-    expect(sql).toMatch(/PRIMARY KEY\s*\(workspace_id,\s*installation_id\)/i);
-    expect(sql).toMatch(/installation_id\s+INTEGER\s+NOT NULL\s+UNIQUE/i);
-    expect(sql).toMatch(/UNIQUE\s*\(workspace_id,\s*account_id\)/i);
-    expect(sql).toMatch(/connection_nonce_hash\s+TEXT\s+NOT NULL\s+UNIQUE/i);
-    expect(sql).toContain("target_account_id");
-    expect(sql).toContain("target_account_login");
-    expect(sql).toContain("target_account_type");
+  it("preserves a 0012 binding through 0013 and 0014 while enforcing multi-account authority", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      db.exec(`
+        PRAGMA foreign_keys = ON;
+        CREATE TABLE workspaces (id TEXT PRIMARY KEY);
+        CREATE TABLE plexus_identities (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+        );
+        CREATE TABLE projects (
+          id TEXT PRIMARY KEY,
+          workspace_id TEXT NOT NULL,
+          FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+        );
+        INSERT INTO workspaces (id) VALUES ('ws_test');
+        INSERT INTO plexus_identities (id, workspace_id) VALUES ('pid_admin', 'ws_test');
+      `);
+      db.exec(readFileSync(new URL("../../../migrations/0012_github_app_control_plane.sql", import.meta.url), "utf8"));
+      db.exec(`
+        INSERT INTO github_connection_states (
+          nonce_hash, workspace_id, plexus_actor_id, expires_at, consumed_at,
+          oauth_user_id, oauth_login, oauth_verified_at, untrusted_installation_id,
+          status, created_at, updated_at
+        ) VALUES (
+          'nonce-legacy', 'ws_test', 'pid_admin', 1999999999, '2026-07-13T00:00:00Z',
+          7611727, 'Sheshiyer', '2026-07-13T00:00:00Z', 42,
+          'bound', '2026-07-13T00:00:00Z', '2026-07-13T00:00:00Z'
+        );
+        INSERT INTO github_installation_facts (
+          installation_id, account_id, account_login, account_type,
+          installer_sender_id, installer_sender_login, last_actor_id, last_actor_login,
+          repository_selection, state, last_delivery_id, observed_at, updated_at
+        ) VALUES (
+          42, 65741640, 'thoughtseed-labs', 'Organization',
+          7611727, 'Sheshiyer', 7611727, 'Sheshiyer',
+          'selected', 'active', 'delivery-legacy', '2026-07-13T00:00:00Z', '2026-07-13T00:00:00Z'
+        );
+        INSERT INTO github_workspace_installations (
+          workspace_id, installation_id, connected_by_identity_id,
+          verified_github_user_id, verified_github_login, connection_nonce_hash,
+          state, created_at, updated_at
+        ) VALUES (
+          'ws_test', 42, 'pid_admin', 7611727, 'Sheshiyer', 'nonce-legacy',
+          'active', '2026-07-13T00:00:00Z', '2026-07-13T00:00:00Z'
+        );
+      `);
+
+      db.exec(readFileSync(new URL("../../../migrations/0013_github_workspace_actors.sql", import.meta.url), "utf8"));
+      db.exec(readFileSync(new URL("../../../migrations/0014_github_multi_owner_installations.sql", import.meta.url), "utf8"));
+
+      expect(db.prepare(`
+        SELECT workspace_id, installation_id, account_id
+        FROM github_workspace_installations
+        WHERE workspace_id = 'ws_test' AND installation_id = 42
+      `).get()).toMatchObject({ workspace_id: "ws_test", installation_id: 42, account_id: 65741640 });
+      expect(db.prepare(`
+        SELECT github_user_id, github_login, verification_source
+        FROM github_workspace_actors
+        WHERE workspace_id = 'ws_test' AND plexus_identity_id = 'pid_admin'
+      `).get()).toMatchObject({ github_user_id: 7611727, github_login: "Sheshiyer", verification_source: "installation" });
+
+      const targetColumns = db.prepare("PRAGMA table_info(github_connection_states)").all()
+        .map((column) => String(column.name))
+        .filter((name) => name.startsWith("target_account_"));
+      expect(targetColumns).toEqual(["target_account_id", "target_account_login", "target_account_type"]);
+
+      db.exec(`
+        INSERT INTO github_connection_states (
+          nonce_hash, workspace_id, plexus_actor_id, expires_at, consumed_at,
+          oauth_user_id, oauth_login, oauth_verified_at, untrusted_installation_id,
+          target_account_id, target_account_login, target_account_type,
+          status, created_at, updated_at
+        ) VALUES (
+          'nonce-founder', 'ws_test', 'pid_admin', 1999999999, '2026-07-14T00:00:00Z',
+          7611727, 'Sheshiyer', '2026-07-14T00:00:00Z', 84,
+          7611727, 'Sheshiyer', 'User',
+          'bound', '2026-07-14T00:00:00Z', '2026-07-14T00:00:00Z'
+        );
+        INSERT INTO github_installation_facts (
+          installation_id, account_id, account_login, account_type,
+          installer_sender_id, installer_sender_login, last_actor_id, last_actor_login,
+          repository_selection, state, last_delivery_id, observed_at, updated_at
+        ) VALUES (
+          84, 7611727, 'Sheshiyer', 'User',
+          7611727, 'Sheshiyer', 7611727, 'Sheshiyer',
+          'selected', 'active', 'delivery-founder', '2026-07-14T00:00:00Z', '2026-07-14T00:00:00Z'
+        );
+        INSERT INTO github_workspace_installations (
+          workspace_id, installation_id, account_id, connected_by_identity_id,
+          verified_github_user_id, verified_github_login, connection_nonce_hash,
+          state, created_at, updated_at
+        ) VALUES (
+          'ws_test', 84, 7611727, 'pid_admin',
+          7611727, 'Sheshiyer', 'nonce-founder',
+          'active', '2026-07-14T00:00:00Z', '2026-07-14T00:00:00Z'
+        );
+      `);
+      expect(db.prepare(`
+        SELECT installation_id, account_id
+        FROM github_workspace_installations
+        WHERE workspace_id = 'ws_test'
+        ORDER BY installation_id
+      `).all()).toEqual([
+        { installation_id: 42, account_id: 65741640 },
+        { installation_id: 84, account_id: 7611727 },
+      ]);
+
+      db.exec(`
+        INSERT INTO github_connection_states (
+          nonce_hash, workspace_id, plexus_actor_id, expires_at,
+          target_account_id, target_account_login, target_account_type,
+          status, created_at, updated_at
+        ) VALUES (
+          'nonce-duplicate', 'ws_test', 'pid_admin', 1999999999,
+          7611727, 'Sheshiyer', 'User',
+          'pending_oauth', '2026-07-14T00:00:00Z', '2026-07-14T00:00:00Z'
+        );
+        INSERT INTO github_installation_facts (
+          installation_id, account_id, account_login, account_type,
+          installer_sender_id, installer_sender_login, last_actor_id, last_actor_login,
+          repository_selection, state, last_delivery_id, observed_at, updated_at
+        ) VALUES (
+          126, 7611727, 'Sheshiyer', 'User',
+          7611727, 'Sheshiyer', 7611727, 'Sheshiyer',
+          'selected', 'active', 'delivery-duplicate', '2026-07-14T00:00:00Z', '2026-07-14T00:00:00Z'
+        );
+      `);
+      expect(() => db.exec(`
+        INSERT INTO github_workspace_installations (
+          workspace_id, installation_id, account_id, connected_by_identity_id,
+          verified_github_user_id, verified_github_login, connection_nonce_hash,
+          state, created_at, updated_at
+        ) VALUES (
+          'ws_test', 126, 7611727, 'pid_admin',
+          7611727, 'Sheshiyer', 'nonce-duplicate',
+          'active', '2026-07-14T00:00:00Z', '2026-07-14T00:00:00Z'
+        )
+      `)).toThrow(/UNIQUE constraint failed/);
+      expect(db.prepare("PRAGMA foreign_key_check").all()).toEqual([]);
+    } finally {
+      db.close();
+    }
   });
 });

--- a/cloudflare/worker/src/routes/__tests__/github.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/github.test.ts
@@ -555,6 +555,75 @@ describe("GitHub App routes", () => {
     vi.unstubAllGlobals();
   });
 
+  it("skips active bindings with forbidden repository selection or removed allowlist authority when a valid binding remains", async () => {
+    const bindings = [
+      { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", state: "active", repository_selection: "selected" },
+      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "all" },
+      { workspace_id: "ws_test", installation_id: 126, account_id: 999, account_login: "former-owner", account_type: "User", state: "active", repository_selection: "selected" },
+    ];
+    const db: D1DatabaseLike = {
+      prepare(sql: string) {
+        const statement = {
+          bind() { return statement; },
+          async first<T>() { return null as T | null; },
+          async all<T>() { return { results: (sql.includes("FROM github_workspace_installations b") ? bindings : []) as T[] }; },
+          async run() { return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/app/installations/42/access_tokens")) {
+        return new Response(JSON.stringify({ token: "org-token", expires_at: new Date(Date.now() + 30 * 60_000).toISOString() }), { status: 201 });
+      }
+      if (url.includes("/installation/repositories")) {
+        return new Response(JSON.stringify({ repositories: [{ id: 101, name: "plexus", full_name: "thoughtseed/plexus", private: true, default_branch: "main", owner: { id: 8, login: "thoughtseed" } }] }));
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.stubGlobal("fetch", fetcher);
+
+    const response = await handleGithubRepositories(env(db), principal("admin"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        repositories: [expect.objectContaining({ id: 101, installationId: 42 })],
+      },
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher.mock.calls.some(([input]) => /installations\/(84|126)\//.test(String(input)))).toBe(false);
+    vi.unstubAllGlobals();
+  });
+
+  it("fails closed when no active binding has selected repositories and current allowlist authority", async () => {
+    const bindings = [
+      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "all" },
+      { workspace_id: "ws_test", installation_id: 126, account_id: 999, account_login: "former-owner", account_type: "User", state: "active", repository_selection: "selected" },
+    ];
+    const db: D1DatabaseLike = {
+      prepare(sql: string) {
+        const statement = {
+          bind() { return statement; },
+          async first<T>() { return null as T | null; },
+          async all<T>() { return { results: (sql.includes("FROM github_workspace_installations b") ? bindings : []) as T[] }; },
+          async run() { return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+    const fetcher = vi.fn();
+    vi.stubGlobal("fetch", fetcher);
+
+    const response = await handleGithubRepositories(env(db), principal("admin"));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "github_unconfigured" } });
+    expect(fetcher).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
   it("ignores signed public-App installation events for non-allowlisted accounts before persisting facts", async () => {
     const store = recordingDeliveryDb();
     const payload = JSON.stringify({

--- a/cloudflare/worker/src/routes/__tests__/github.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/github.test.ts
@@ -1,8 +1,8 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { D1DatabaseLike, Env } from "../../lib/env";
 import type { PlexusPrincipal } from "../../lib/plexus-session";
-import { handleGithubActivitySync, handleGithubActor, handleGithubActorEnrollStart, handleGithubCallback, handleGithubConnection, handleGithubPullRequest, handleGithubRepoVerify, handleGithubWebhook, nextInstallationState, reconcileBinding, validateWriteFiles } from "../github";
-import { sha256Hex, signConnectState } from "../../lib/github-app";
+import { handleGithubActivitySync, handleGithubActor, handleGithubActorEnrollStart, handleGithubCallback, handleGithubConnection, handleGithubConnectStart, handleGithubPullRequest, handleGithubRepositories, handleGithubRepoVerify, handleGithubWebhook, nextInstallationState, reconcileBinding, validateWriteFiles } from "../github";
+import { sha256Hex, signConnectState, verifyConnectState } from "../../lib/github-app";
 
 let privateKeyPem = "";
 
@@ -31,7 +31,7 @@ function principal(role: "employee" | "admin" = "employee"): PlexusPrincipal {
   };
 }
 
-function activityDb(): D1DatabaseLike {
+function activityDb(installationId = 42): D1DatabaseLike {
   return {
     prepare(sql: string) {
       let args: unknown[] = [];
@@ -40,14 +40,19 @@ function activityDb(): D1DatabaseLike {
         async first<T>() {
           if (sql.includes("FROM projects WHERE id")) return ({ id: args[0] } as T);
           if (sql.includes("FROM github_workspace_installations b")) {
-            return ({ workspace_id: "ws_test", installation_id: 42, connected_by_identity_id: "pid_admin", verified_github_user_id: 7, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
+            return ({ workspace_id: "ws_test", installation_id: installationId, connected_by_identity_id: "pid_admin", verified_github_user_id: 7, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
           }
           if (sql.includes("FROM project_github_verifications v")) {
-            return ({ project_id: "proj_test", workspace_id: "ws_test", installation_id: 42, repository_id: 101, repo_owner: "thoughtseed", repo_name: "private-repo", default_branch: "main", verified_at: "2026-07-13T00:00:00.000Z", owner_login: "thoughtseed", name: "private-repo", full_name: "thoughtseed/private-repo", is_private: 1, state: "active" } as T);
+            return ({ project_id: "proj_test", workspace_id: "ws_test", installation_id: installationId, repository_id: 101, repo_owner: "thoughtseed", repo_name: "private-repo", default_branch: "main", verified_at: "2026-07-13T00:00:00.000Z", owner_login: "thoughtseed", name: "private-repo", full_name: "thoughtseed/private-repo", is_private: 1, state: "active" } as T);
           }
           return null;
         },
-        async all<T>() { return { results: [] as T[] }; },
+        async all<T>() {
+          if (sql.includes("FROM github_workspace_installations b")) {
+            return { results: [{ workspace_id: "ws_test", installation_id: installationId, account_id: 8, account_login: "thoughtseed", account_type: "Organization", connected_by_identity_id: "pid_admin", verified_github_user_id: 7, verified_github_login: "installer", state: "active", repository_selection: "selected" }] as T[] };
+          }
+          return { results: [] as T[] };
+        },
         async run() { return { success: true, meta: { changes: 1 } }; },
       };
       return statement;
@@ -73,7 +78,12 @@ function deliveryDb(initial?: { event: string; hash: string; result: string; pro
           if (sql.includes("FROM github_webhook_deliveries")) return ((deliveries.get(String(args[0])) ?? null) as T | null);
           return null;
         },
-        async all<T>() { return { results: [] as T[] }; },
+        async all<T>() {
+          if (sql.includes("FROM github_workspace_installations b")) {
+            return { results: [{ workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected" }] as T[] };
+          }
+          return { results: [] as T[] };
+        },
         async run() {
           if (sql.includes("INSERT OR IGNORE INTO github_webhook_deliveries")) {
             const id = String(args[0]);
@@ -106,7 +116,39 @@ function deliveryDb(initial?: { event: string; hash: string; result: string; pro
   };
 }
 
-function writeDb(existing: Record<string, unknown> | null = null): { db: D1DatabaseLike; runs: Array<{ sql: string; args: unknown[] }> } {
+function recordingDeliveryDb(): { db: D1DatabaseLike; runs: Array<{ sql: string; args: unknown[] }> } {
+  const runs: Array<{ sql: string; args: unknown[] }> = [];
+  const deliveries = new Map<string, { event_name: string; payload_sha256: string; result: string; processing_started_at: string }>();
+  const db: D1DatabaseLike = {
+    prepare(sql: string) {
+      let args: unknown[] = [];
+      const statement = {
+        bind(...values: unknown[]) { args = values; return statement; },
+        async first<T>() {
+          if (sql.includes("FROM github_webhook_deliveries")) return ((deliveries.get(String(args[0])) ?? null) as T | null);
+          return null;
+        },
+        async all<T>() {
+          if (sql.includes("FROM github_workspace_installations b")) {
+            return { results: [{ workspace_id: "ws_test", installation_id: 42, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" }] as T[] };
+          }
+          return { results: [] as T[] };
+        },
+        async run() {
+          runs.push({ sql, args: [...args] });
+          if (sql.includes("INSERT OR IGNORE INTO github_webhook_deliveries")) {
+            deliveries.set(String(args[0]), { event_name: String(args[1]), payload_sha256: String(args[2]), result: "processing", processing_started_at: String(args[4]) });
+          }
+          return { success: true, meta: { changes: 1 } };
+        },
+      };
+      return statement;
+    },
+  };
+  return { db, runs };
+}
+
+function writeDb(existing: Record<string, unknown> | null = null, installationId = 42): { db: D1DatabaseLike; runs: Array<{ sql: string; args: unknown[] }> } {
   const runs: Array<{ sql: string; args: unknown[] }> = [];
   const db: D1DatabaseLike = {
     prepare(sql: string) {
@@ -117,12 +159,17 @@ function writeDb(existing: Record<string, unknown> | null = null): { db: D1Datab
           if (sql.includes("FROM projects WHERE id")) return ({ id: args[0] } as T);
           if (sql.includes("FROM plexus_identities")) return ({ id: "pid_admin" } as T);
           if (sql.includes("FROM github_workspace_actors")) return ({ workspace_id: "ws_test", plexus_identity_id: "pid_admin", github_user_id: 77, github_login: "installer", verified_at: "2026-07-13T00:00:00.000Z", verification_source: "oauth" } as T);
-          if (sql.includes("FROM github_workspace_installations b")) return ({ workspace_id: "ws_test", installation_id: 42, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
-          if (sql.includes("FROM project_github_verifications v")) return ({ project_id: "proj_test", workspace_id: "ws_test", installation_id: 42, repository_id: 101, repo_owner: "thoughtseed", repo_name: "private-repo", default_branch: "main", verified_at: "2026-07-13T00:00:00.000Z", owner_login: "thoughtseed", name: "private-repo", full_name: "thoughtseed/private-repo", is_private: 1, state: "active" } as T);
+          if (sql.includes("FROM github_workspace_installations b")) return ({ workspace_id: "ws_test", installation_id: installationId, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
+          if (sql.includes("FROM project_github_verifications v")) return ({ project_id: "proj_test", workspace_id: "ws_test", installation_id: installationId, repository_id: 101, repo_owner: "thoughtseed", repo_name: "private-repo", default_branch: "main", verified_at: "2026-07-13T00:00:00.000Z", owner_login: "thoughtseed", name: "private-repo", full_name: "thoughtseed/private-repo", is_private: 1, state: "active" } as T);
           if (sql.includes("FROM github_write_operations")) return (existing as T | null);
           return null;
         },
-        async all<T>() { return { results: [] as T[] }; },
+        async all<T>() {
+          if (sql.includes("FROM github_workspace_installations b")) {
+            return { results: [{ workspace_id: "ws_test", installation_id: installationId, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" }] as T[] };
+          }
+          return { results: [] as T[] };
+        },
         async run() { runs.push({ sql, args: [...args] }); return { success: true, meta: { changes: 1 } }; },
       };
       return statement;
@@ -142,11 +189,13 @@ function writeRequest(files: Array<{ path: string; content: string }> = [{ path:
 function guardedWriteFetch(permission: unknown, options: { staleBase?: boolean; finalRace?: boolean } = {}) {
   const mutations: Array<{ url: string; body: Record<string, unknown> }> = [];
   let tokenRequest: Record<string, unknown> | null = null;
+  let tokenUrl: string | null = null;
   let defaultRefReads = 0;
   const fetcher = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
     const method = init?.method ?? "GET";
     if (url.includes("/access_tokens")) {
+      tokenUrl = url;
       tokenRequest = JSON.parse(String(init?.body)) as Record<string, unknown>;
       return new Response(JSON.stringify({ token: "write-token", expires_at: new Date(Date.now() + 30 * 60_000).toISOString() }), { status: 201 });
     }
@@ -181,7 +230,7 @@ function guardedWriteFetch(permission: unknown, options: { staleBase?: boolean; 
     }
     throw new Error(`unexpected fetch ${method} ${url}`);
   });
-  return { fetcher, mutations, tokenRequest: () => tokenRequest };
+  return { fetcher, mutations, tokenRequest: () => tokenRequest, tokenUrl: () => tokenUrl };
 }
 
 function reconciliationDb(
@@ -190,7 +239,7 @@ function reconciliationDb(
   organization: { id: number; login: string; type: string } = { id: 8, login: "thoughtseed", type: "Organization" },
 ) {
   let bound = false;
-  const state = { nonce_hash: "nonce-hash", workspace_id: "ws_test", plexus_actor_id: "pid_admin", expires_at: Math.floor(Date.now() / 1000) + 600, consumed_at: "now", oauth_user_id: 77, oauth_login: "installer", oauth_verified_at: "now", untrusted_installation_id: 42, status: "oauth_verified" };
+  const state = { nonce_hash: "nonce-hash", workspace_id: "ws_test", plexus_actor_id: "pid_admin", expires_at: Math.floor(Date.now() / 1000) + 600, consumed_at: "now", oauth_user_id: 77, oauth_login: "installer", oauth_verified_at: "now", untrusted_installation_id: 42, target_account_id: 8, target_account_login: "thoughtseed", target_account_type: "Organization", status: "oauth_verified" };
   const db: D1DatabaseLike = {
     prepare(sql: string) {
       let args: unknown[] = [];
@@ -227,6 +276,9 @@ function connectionFlowDb(nonceHash: string) {
     oauth_login: null,
     oauth_verified_at: null,
     untrusted_installation_id: null,
+    target_account_id: 8,
+    target_account_login: "thoughtseed",
+    target_account_type: "Organization",
     status: "pending_oauth",
   };
   let fact: Record<string, unknown> | null = null;
@@ -278,7 +330,7 @@ function connectionFlowDb(nonceHash: string) {
             return { success: true, meta: { changes: 1 } };
           }
           if (sql.includes("INSERT INTO github_workspace_installations")) {
-            binding = { workspace_id: args[0], installation_id: args[1], connected_by_identity_id: args[2], verified_github_user_id: args[3], verified_github_login: args[4], state: args[6] };
+            binding = { workspace_id: args[0], installation_id: args[1], account_id: args[2], connected_by_identity_id: args[3], verified_github_user_id: args[4], verified_github_login: args[5], state: args[7] };
             return { success: true, meta: { changes: 1 } };
           }
           if (sql.includes("UPDATE github_connection_states SET status = 'bound'")) state.status = "bound";
@@ -298,6 +350,7 @@ function connectionFlowDb(nonceHash: string) {
 function actorEnrollmentDb(
   initialActor: Record<string, unknown> | null = null,
   concurrentActor: Record<string, unknown> | null = null,
+  installationIds: number[] = [42],
 ) {
   let actorState: Record<string, unknown> | null = null;
   let actor: Record<string, unknown> | null = initialActor;
@@ -310,7 +363,7 @@ function actorEnrollmentDb(
         async first<T>() {
           if (sql.includes("FROM plexus_identities")) return ({ id: "pid_admin" } as T);
           if (sql.includes("FROM github_workspace_installations b")) {
-            return ({ workspace_id: "ws_test", installation_id: 42, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
+            return ({ workspace_id: "ws_test", installation_id: installationIds[0], connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
           }
           if (sql.includes("FROM github_actor_connection_states")) {
             if (!actorState) return null;
@@ -325,7 +378,12 @@ function actorEnrollmentDb(
           }
           return null;
         },
-        async all<T>() { return { results: [] as T[] }; },
+        async all<T>() {
+          if (sql.includes("FROM github_workspace_installations b")) {
+            return { results: installationIds.map((installationId) => ({ workspace_id: "ws_test", installation_id: installationId, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" })) as T[] };
+          }
+          return { results: [] as T[] };
+        },
         async run() {
           runs.push({ sql, args: [...args] });
           if (sql.includes("INSERT INTO github_actor_connection_states")) {
@@ -371,13 +429,150 @@ function env(db: D1DatabaseLike): Env {
     TF_GITHUB_APP_CALLBACK_URL: "https://worker.test/v1/github/callback",
     TF_GITHUB_APP_WEBHOOK_SECRET: "webhook-test-secret",
     TF_GITHUB_APP_STATE_SIGNING_SECRET: "s".repeat(32),
-    TF_GITHUB_EXPECTED_ORG: "thoughtseed",
-    TF_GITHUB_EXPECTED_ORG_ID: "8",
+    TF_GITHUB_ALLOWED_INSTALLATION_ACCOUNTS: "Organization:thoughtseed:8,User:Sheshiyer:7611727,User:psychon7:47470954",
     TF_GITHUB_ALLOWED_ACTORS: "installer:77,Sheshiyer:7611727,psychon7:47470954",
   };
 }
 
 describe("GitHub App routes", () => {
+  it("binds a connection start to one exact allowlisted installation account", async () => {
+    const runs: Array<{ sql: string; args: unknown[] }> = [];
+    const db: D1DatabaseLike = {
+      prepare(sql: string) {
+        let args: unknown[] = [];
+        const statement = {
+          bind(...values: unknown[]) { args = values; return statement; },
+          async first<T>() { return null as T | null; },
+          async all<T>() {
+            if (sql.includes("FROM github_workspace_installations b")) {
+              return { results: [{ workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected" }] as T[] };
+            }
+            return { results: [] as T[] };
+          },
+          async run() { runs.push({ sql, args: [...args] }); return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+    const response = await handleGithubConnectStart(
+      env(db),
+      new Request("https://worker.test/v1/github/connect/start", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ accountId: 7611727 }),
+      }),
+      principal("admin"),
+    );
+    expect(response.status).toBe(201);
+    const payload = await response.json() as { data: { authorizeUrl: string; target: { id: number; login: string; type: string } } };
+    expect(payload.data.target).toEqual({ id: 7611727, login: "Sheshiyer", type: "User" });
+    const signedState = new URL(payload.data.authorizeUrl).searchParams.get("state")!;
+    await expect(verifyConnectState(signedState, "s".repeat(32))).resolves.toMatchObject({
+      target: { id: 7611727, login: "Sheshiyer", type: "User" },
+    });
+    expect(runs.find((run) => run.sql.includes("INSERT INTO github_connection_states"))?.args).toContain(7611727);
+  });
+
+  it("returns all workspace installations and exact allowed targets", async () => {
+    const bindings = [
+      { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected" },
+      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "suspended", repository_selection: "selected" },
+    ];
+    const db: D1DatabaseLike = {
+      prepare(sql: string) {
+        const statement = {
+          bind() { return statement; },
+          async first<T>() { return null as T | null; },
+          async all<T>() { return { results: (sql.includes("FROM github_workspace_installations b") ? bindings : []) as T[] }; },
+          async run() { return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+    const response = await handleGithubConnection(env(db), principal("admin"));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        status: "connected",
+        installations: [
+          { installationId: 42, status: "connected", account: { id: 8, login: "thoughtseed", type: "Organization" } },
+          { installationId: 84, status: "suspended", account: { id: 7611727, login: "Sheshiyer", type: "User" } },
+        ],
+        allowedTargets: [
+          { id: 8, login: "thoughtseed", type: "Organization" },
+          { id: 7611727, login: "Sheshiyer", type: "User" },
+          { id: 47470954, login: "psychon7", type: "User" },
+        ],
+      },
+    });
+  });
+
+  it("rejects installation allowlist entries with extra authority segments", async () => {
+    const invalidEnv = {
+      ...env(activityDb()),
+      TF_GITHUB_ALLOWED_INSTALLATION_ACCOUNTS: "Organization:thoughtseed:8:extra",
+    };
+    const response = await handleGithubConnection(invalidEnv, principal("admin"));
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "github_installation_policy_invalid" } });
+  });
+
+  it("aggregates repositories across active installations with installation and account metadata", async () => {
+    const bindings = [
+      { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", state: "active", repository_selection: "selected" },
+      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "selected" },
+    ];
+    const db: D1DatabaseLike = {
+      prepare(sql: string) {
+        const statement = {
+          bind() { return statement; },
+          async first<T>() { return null as T | null; },
+          async all<T>() { return { results: (sql.includes("FROM github_workspace_installations b") ? bindings : []) as T[] }; },
+          async run() { return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/app/installations/42/access_tokens")) return new Response(JSON.stringify({ token: "org-token", expires_at: new Date(Date.now() + 30 * 60_000).toISOString() }), { status: 201 });
+      if (url.includes("/app/installations/84/access_tokens")) return new Response(JSON.stringify({ token: "user-token", expires_at: new Date(Date.now() + 30 * 60_000).toISOString() }), { status: 201 });
+      if (url.includes("/installation/repositories") && new Headers(init?.headers).get("authorization") === "Bearer org-token") {
+        return new Response(JSON.stringify({ repositories: [{ id: 101, name: "plexus", full_name: "thoughtseed/plexus", private: true, default_branch: "main", owner: { id: 8, login: "thoughtseed" } }] }));
+      }
+      if (url.includes("/installation/repositories")) {
+        return new Response(JSON.stringify({ repositories: [{ id: 202, name: "parkarea", full_name: "Sheshiyer/parkarea", private: true, default_branch: "main", owner: { id: 7611727, login: "Sheshiyer" } }] }));
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+    const response = await handleGithubRepositories(env(db), principal("admin"));
+    expect(response.status).toBe(200);
+    const payload = await response.json() as { data: { repositories: Array<Record<string, unknown>> } };
+    expect(payload.data.repositories).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 101, installationId: 42, account: { id: 8, login: "thoughtseed", type: "Organization" } }),
+      expect.objectContaining({ id: 202, installationId: 84, account: { id: 7611727, login: "Sheshiyer", type: "User" } }),
+    ]));
+    vi.unstubAllGlobals();
+  });
+
+  it("ignores signed public-App installation events for non-allowlisted accounts before persisting facts", async () => {
+    const store = recordingDeliveryDb();
+    const payload = JSON.stringify({
+      action: "created",
+      installation: { id: 999, account: { id: 999, login: "outsider", type: "User" }, repository_selection: "selected" },
+      sender: { id: 77, login: "installer" },
+      repositories: [],
+    });
+    const response = await handleGithubWebhook(env(store.db), new Request("https://worker.test/v1/github/webhook", {
+      method: "POST",
+      headers: { "x-hub-signature-256": await webhookSignature(payload, "webhook-test-secret"), "x-github-delivery": "delivery-outsider", "x-github-event": "installation" },
+      body: payload,
+    }));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ data: { status: "ignored" } });
+    expect(store.runs.some((run) => run.sql.includes("github_installation_facts") || run.sql.includes("github_installation_repositories"))).toBe(false);
+  });
+
   it("keeps suspended and deleted installations closed across late events", () => {
     expect(nextInstallationState("suspended", "installation_repositories", "added")).toBe("suspended");
     expect(nextInstallationState("suspended", "installation", "new_permissions_accepted")).toBe("suspended");
@@ -394,21 +589,24 @@ describe("GitHub App routes", () => {
     expect(() => validateWriteFiles([{ path: "src/a.ts", content: "x" }, { path: "src/a.ts", content: "y" }])).toThrow(/unsafe/);
   });
 
-  it("enrolls an active Plexus administrator through one-time OAuth and stores only the numeric actor", async () => {
-    const fixture = actorEnrollmentDb();
+  it.each([
+    ["Sheshiyer", 7611727],
+    ["psychon7", 47470954],
+  ])("enrolls allowed founder %s through one-time OAuth and stores only the numeric actor", async (login, userId) => {
+    const fixture = actorEnrollmentDb(null, null, [42, 84]);
     const actorEnv = { ...env(fixture.db), TF_GITHUB_ALLOWED_ACTORS: "Sheshiyer:7611727,psychon7:47470954" };
     const start = await handleGithubActorEnrollStart(actorEnv, principal("admin"));
     expect(start.status).toBe(201);
-    const startPayload = await start.json() as { data: { authorizeUrl: string; organization: { id: number; login: string } } };
-    expect(startPayload.data.organization).toEqual({ id: 8, login: "thoughtseed" });
+    const startPayload = await start.json() as { data: { authorizeUrl: string; allowedLogins: string[] } };
+    expect(startPayload.data.allowedLogins).toEqual(["Sheshiyer", "psychon7"]);
     const stateValue = new URL(startPayload.data.authorizeUrl).searchParams.get("state");
     expect(stateValue).toBeTruthy();
 
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url === "https://github.com/login/oauth/access_token") return new Response(JSON.stringify({ access_token: "ephemeral-oauth-token" }));
-      if (url === "https://api.github.com/user") return new Response(JSON.stringify({ id: 7611727, login: "Sheshiyer" }));
-      if (url === "https://api.github.com/user/installations?per_page=100&page=1") return new Response(JSON.stringify({ installations: [{ id: 42 }] }));
+      if (url === "https://api.github.com/user") return new Response(JSON.stringify({ id: userId, login }));
+      if (url === "https://api.github.com/user/installations?per_page=100&page=1") return new Response(JSON.stringify({ installations: [{ id: 84 }] }));
       throw new Error(`unexpected fetch ${url}`);
     }));
     const callback = await handleGithubCallback(
@@ -417,11 +615,11 @@ describe("GitHub App routes", () => {
       new URL(`https://worker.test/v1/github/callback?state=${encodeURIComponent(stateValue!)}&code=one-time-code`),
     );
     expect(callback.status).toBe(200);
-    expect(fixture.actor()).toMatchObject({ github_user_id: 7611727, github_login: "Sheshiyer", plexus_identity_id: "pid_admin", verification_source: "oauth" });
+    expect(fixture.actor()).toMatchObject({ github_user_id: userId, github_login: login, plexus_identity_id: "pid_admin", verification_source: "oauth" });
     expect(JSON.stringify(fixture.runs)).not.toContain("ephemeral-oauth-token");
 
     const status = await handleGithubActor(actorEnv, principal("admin"));
-    await expect(status.json()).resolves.toMatchObject({ data: { status: "verified", actor: { id: 7611727, login: "Sheshiyer" } } });
+    await expect(status.json()).resolves.toMatchObject({ data: { status: "verified", actor: { id: userId, login } } });
     const replay = await handleGithubCallback(
       actorEnv,
       new Request("https://worker.test/v1/github/callback"),
@@ -567,7 +765,7 @@ describe("GitHub App routes", () => {
   it("atomically consumes OAuth state and rejects a second code callback", async () => {
     const nonce = "nonce-atomic";
     const stateValue = await signConnectState(
-      { workspace: "ws_test", actor: "pid_admin", nonce, exp: Math.floor(Date.now() / 1000) + 600 },
+      { workspace: "ws_test", actor: "pid_admin", nonce, exp: Math.floor(Date.now() / 1000) + 600, target: { id: 8, login: "thoughtseed", type: "Organization" } },
       "s".repeat(32),
     );
     const state: Record<string, unknown> = {
@@ -580,6 +778,9 @@ describe("GitHub App routes", () => {
       oauth_login: null,
       oauth_verified_at: null,
       untrusted_installation_id: null,
+      target_account_id: 8,
+      target_account_login: "thoughtseed",
+      target_account_type: "Organization",
       status: "pending_oauth",
     };
     const db: D1DatabaseLike = {
@@ -633,7 +834,7 @@ describe("GitHub App routes", () => {
     const secret = "webhook-test-secret";
     const flowEnv = { ...env(fixture.db), TF_GITHUB_APP_WEBHOOK_SECRET: secret };
     const stateValue = await signConnectState(
-      { workspace: "ws_test", actor: "pid_admin", nonce, exp: Math.floor(Date.now() / 1000) + 600 },
+      { workspace: "ws_test", actor: "pid_admin", nonce, exp: Math.floor(Date.now() / 1000) + 600, target: { id: 8, login: "thoughtseed", type: "Organization" } },
       "s".repeat(32),
     );
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
@@ -726,7 +927,7 @@ describe("GitHub App routes", () => {
 
   it("binds only the exact hinted installation even for the same GitHub actor", async () => {
     const bound: number[] = [];
-    const state = { nonce_hash: "nonce-hash", workspace_id: "ws_test", plexus_actor_id: "pid_admin", expires_at: Math.floor(Date.now() / 1000) + 600, consumed_at: "now", oauth_user_id: 77, oauth_login: "installer", oauth_verified_at: "now", untrusted_installation_id: 42, status: "oauth_verified" };
+    const state = { nonce_hash: "nonce-hash", workspace_id: "ws_test", plexus_actor_id: "pid_admin", expires_at: Math.floor(Date.now() / 1000) + 600, consumed_at: "now", oauth_user_id: 77, oauth_login: "installer", oauth_verified_at: "now", untrusted_installation_id: 42, target_account_id: 8, target_account_login: "thoughtseed", target_account_type: "Organization", status: "oauth_verified" };
     const db: D1DatabaseLike = {
       prepare(sql: string) {
         let args: unknown[] = [];
@@ -769,7 +970,7 @@ describe("GitHub App routes", () => {
     ["personal account", { id: 8, login: "thoughtseed", type: "User" }],
   ])("rejects installation binding for %s", async (_label, organization) => {
     const fixture = reconciliationDb("selected", true, organization);
-    await expect(reconcileBinding(env(fixture.db), "nonce-hash")).rejects.toMatchObject({ code: "github_organization_forbidden" });
+    await expect(reconcileBinding(env(fixture.db), "nonce-hash")).rejects.toMatchObject({ code: "github_installation_account_forbidden" });
     expect(fixture.wasBound()).toBe(false);
   });
 
@@ -816,7 +1017,7 @@ describe("GitHub App routes", () => {
       throw new Error(`unexpected fetch ${url}`);
     }));
     const request = new Request("https://worker.test/v1/projects/proj_test/github-repo/verify", {
-      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ repositoryId: 101 }),
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ installationId: 42, repositoryId: 101 }),
     });
     const response = await handleGithubRepoVerify(env(db), request, "proj_test", principal("admin"));
     expect(response.status).toBe(409);
@@ -863,6 +1064,16 @@ describe("GitHub App routes", () => {
     vi.unstubAllGlobals();
   });
 
+  it("uses the project verification's persisted non-default installation for guarded writes", async () => {
+    const store = writeDb(null, 84);
+    const github = guardedWriteFetch({ permission: "write", user: { id: 77, login: "installer" } });
+    vi.stubGlobal("fetch", github.fetcher);
+    const response = await handleGithubPullRequest(env(store.db), writeRequest(), "proj_test", principal("admin"));
+    expect(response.status).toBe(201);
+    expect(github.tokenUrl()).toContain("/app/installations/84/access_tokens");
+    vi.unstubAllGlobals();
+  });
+
   it("rejects a stale default-branch SHA before tracking or repository mutation", async () => {
     const store = writeDb();
     const github = guardedWriteFetch({ permission: "write", user: { id: 77, login: "installer" } }, { staleBase: true });
@@ -906,9 +1117,11 @@ describe("GitHub App routes", () => {
 
   it("syncs private repository activity for a registered same-workspace member", async () => {
     let tokenRequest: Record<string, unknown> | null = null;
+    let tokenUrl: string | null = null;
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/access_tokens")) {
+        tokenUrl = url;
         tokenRequest = JSON.parse(String(init?.body)) as Record<string, unknown>;
         return new Response(JSON.stringify({ token: "scoped-token", expires_at: new Date(Date.now() + 30 * 60_000).toISOString() }), { status: 201 });
       }
@@ -936,7 +1149,7 @@ describe("GitHub App routes", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ from: "2026-07-13T00:00:00.000Z", to: "2026-07-14T00:00:00.000Z" }),
     });
-    const response = await handleGithubActivitySync(env(activityDb()), request, "proj_test", principal("employee"));
+    const response = await handleGithubActivitySync(env(activityDb(84)), request, "proj_test", principal("employee"));
     expect(response.status).toBe(200);
     const payload = await response.json() as { data: { status: string; activity: Array<{ projectId: string; repoFullName: string; kind: string }>; ciEvidence: { items: Array<{ evidenceClass: string; evidenceType: string; externalId: number; headSha: string; conclusion: string; attempt: number | null; event: string | null; branch: string | null }>; truncated: boolean } } };
     expect(payload.data.status).toBe("synced");
@@ -951,6 +1164,7 @@ describe("GitHub App routes", () => {
       repository_ids: [101],
       permissions: { metadata: "read", contents: "read", pull_requests: "read", issues: "read", actions: "read", checks: "read" },
     });
+    expect(tokenUrl).toContain("/app/installations/84/access_tokens");
     vi.unstubAllGlobals();
   });
 });

--- a/cloudflare/worker/src/routes/github.ts
+++ b/cloudflare/worker/src/routes/github.ts
@@ -11,6 +11,7 @@ import {
   signConnectState,
   verifyConnectState,
   verifyWebhookSignature,
+  type GithubInstallationAccountTarget,
   type GithubRepository,
 } from "../lib/github-app";
 
@@ -24,6 +25,9 @@ interface ConnectionStateRow {
   oauth_login: string | null;
   oauth_verified_at: string | null;
   untrusted_installation_id: number | null;
+  target_account_id: number | null;
+  target_account_login: string | null;
+  target_account_type: "Organization" | "User" | null;
   status: "pending_oauth" | "oauth_verified" | "bound" | "expired" | "rejected";
 }
 
@@ -47,11 +51,14 @@ interface WorkspaceActorRow {
   verification_source: "installation" | "oauth";
 }
 
-interface GithubEnrollmentPolicy {
-  organization: string;
-  organizationId: number;
+interface GithubActorPolicy {
   allowedActors: Array<{ id: number; login: string }>;
   allowedActorByLogin: Map<string, number>;
+}
+
+interface GithubInstallationPolicy {
+  allowedTargets: GithubInstallationAccountTarget[];
+  allowedTargetById: Map<number, GithubInstallationAccountTarget>;
 }
 
 interface InstallationBindingRow {
@@ -61,10 +68,10 @@ interface InstallationBindingRow {
   verified_github_user_id: number;
   verified_github_login: string;
   state: "active" | "suspended" | "revoked";
-  account_id?: number;
-  account_login?: string;
-  account_type?: string;
-  repository_selection?: string;
+  account_id: number;
+  account_login: string;
+  account_type: "Organization" | "User";
+  repository_selection: string;
 }
 
 interface RepositoryAuthorityRow {
@@ -145,20 +152,18 @@ function githubConfigurationPresent(env: Env): boolean {
     env.TF_GITHUB_APP_CALLBACK_URL,
     env.TF_GITHUB_APP_WEBHOOK_SECRET,
     env.TF_GITHUB_APP_STATE_SIGNING_SECRET,
-    env.TF_GITHUB_EXPECTED_ORG,
-    env.TF_GITHUB_EXPECTED_ORG_ID,
+    env.TF_GITHUB_ALLOWED_INSTALLATION_ACCOUNTS,
     env.TF_GITHUB_ALLOWED_ACTORS,
   ].every((value) => Boolean(value?.trim()));
 }
 
-function githubEnrollmentPolicy(env: Env): GithubEnrollmentPolicy {
-  const organization = env.TF_GITHUB_EXPECTED_ORG?.trim() ?? "";
-  const organizationId = Number(env.TF_GITHUB_EXPECTED_ORG_ID);
+const validGithubLogin = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+
+function githubActorPolicy(env: Env): GithubActorPolicy {
   const configuredActors = (env.TF_GITHUB_ALLOWED_ACTORS ?? "")
     .split(",")
     .map((actor) => actor.trim())
     .filter(Boolean);
-  const validLogin = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
   const allowedActors = configuredActors.map((entry) => {
     const separator = entry.lastIndexOf(":");
     const login = separator > 0 ? entry.slice(0, separator).trim() : "";
@@ -167,27 +172,55 @@ function githubEnrollmentPolicy(env: Env): GithubEnrollmentPolicy {
   });
   const allowedActorByLogin = new Map(allowedActors.map((actor) => [actor.login.toLowerCase(), actor.id]));
   const actorIds = new Set(allowedActors.map((actor) => actor.id));
-  if (!validLogin.test(organization) || !Number.isSafeInteger(organizationId) || organizationId <= 0 ||
-    allowedActors.length === 0 || allowedActors.some((actor) => !validLogin.test(actor.login) || !Number.isSafeInteger(actor.id) || actor.id <= 0) ||
+  if (allowedActors.length === 0 || allowedActors.some((actor) => !validGithubLogin.test(actor.login) || !Number.isSafeInteger(actor.id) || actor.id <= 0) ||
     allowedActorByLogin.size !== allowedActors.length || actorIds.size !== allowedActors.length) {
-    throw new GithubControlPlaneError("github_actor_policy_invalid", "GitHub organization and actor allowlist configuration is invalid.", 503);
+    throw new GithubControlPlaneError("github_actor_policy_invalid", "GitHub actor allowlist configuration is invalid.", 503);
   }
-  return { organization, organizationId, allowedActors, allowedActorByLogin };
+  return { allowedActors, allowedActorByLogin };
 }
 
-function isAllowedGithubActor(policy: GithubEnrollmentPolicy, user: { id: number; login: string }): boolean {
+function githubInstallationPolicy(env: Env): GithubInstallationPolicy {
+  const entries = (env.TF_GITHUB_ALLOWED_INSTALLATION_ACCOUNTS ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+  const parsedTargets = entries.map((entry) => entry.split(":").map((part) => part.trim()));
+  const allowedTargets = parsedTargets.map((parts): GithubInstallationAccountTarget => {
+    const type = parts[0] as "Organization" | "User";
+    return { type, login: parts[1] ?? "", id: Number(parts[2] ?? "") };
+  });
+  const allowedTargetById = new Map(allowedTargets.map((target) => [target.id, target]));
+  const logins = new Set(allowedTargets.map((target) => target.login.toLowerCase()));
+  if (allowedTargets.length === 0 || parsedTargets.some((parts) => parts.length !== 3) || allowedTargets.some((target) =>
+    (target.type !== "Organization" && target.type !== "User") || !validGithubLogin.test(target.login) ||
+    !Number.isSafeInteger(target.id) || target.id <= 0) || allowedTargetById.size !== allowedTargets.length || logins.size !== allowedTargets.length) {
+    throw new GithubControlPlaneError("github_installation_policy_invalid", "GitHub installation-account allowlist configuration is invalid.", 503);
+  }
+  return { allowedTargets, allowedTargetById };
+}
+
+function isAllowedGithubActor(policy: GithubActorPolicy, user: { id: number; login: string }): boolean {
   return policy.allowedActorByLogin.get(user.login.toLowerCase()) === user.id;
 }
 
-function assertAllowedGithubActor(policy: GithubEnrollmentPolicy, user: { id: number; login: string }): void {
+function assertAllowedGithubActor(policy: GithubActorPolicy, user: { id: number; login: string }): void {
   if (!isAllowedGithubActor(policy, user)) {
     throw new GithubControlPlaneError("github_actor_forbidden", "GitHub OAuth identity is not allowed for this workspace.", 403);
   }
 }
 
-function assertExpectedOrganization(policy: GithubEnrollmentPolicy, binding: Pick<InstallationBindingRow, "account_id" | "account_login" | "account_type">): void {
-  if (binding.account_type !== "Organization" || binding.account_id !== policy.organizationId || binding.account_login?.toLowerCase() !== policy.organization.toLowerCase()) {
-    throw new GithubControlPlaneError("github_organization_forbidden", "GitHub App installation is not owned by the configured organization.", 403);
+function installationTargetOf(value: Pick<InstallationBindingRow, "account_id" | "account_login" | "account_type">): GithubInstallationAccountTarget {
+  return { id: value.account_id, login: value.account_login, type: value.account_type };
+}
+
+function isAllowedInstallationTarget(policy: GithubInstallationPolicy, value: Pick<InstallationBindingRow, "account_id" | "account_login" | "account_type">): boolean {
+  const expected = policy.allowedTargetById.get(value.account_id);
+  return Boolean(expected && expected.type === value.account_type && expected.login.toLowerCase() === value.account_login.toLowerCase());
+}
+
+function assertAllowedInstallationTarget(policy: GithubInstallationPolicy, value: Pick<InstallationBindingRow, "account_id" | "account_login" | "account_type">): void {
+  if (!isAllowedInstallationTarget(policy, value)) {
+    throw new GithubControlPlaneError("github_installation_account_forbidden", "GitHub App installation account is not allowlisted.", 403);
   }
 }
 
@@ -218,25 +251,49 @@ async function parseJsonObject(request: Request): Promise<Record<string, unknown
   }
 }
 
-async function getBinding(env: Env, workspaceId: string): Promise<InstallationBindingRow | null> {
-  return queryFirst<InstallationBindingRow>(
+async function getBindings(env: Env, workspaceId: string): Promise<InstallationBindingRow[]> {
+  return queryAll<InstallationBindingRow>(
     database(env),
-    `SELECT b.*, f.account_id, f.account_login, f.account_type, f.repository_selection
+    `SELECT b.*, f.account_login, f.account_type, f.repository_selection
        FROM github_workspace_installations b
        JOIN github_installation_facts f ON f.installation_id = b.installation_id
-      WHERE b.workspace_id = ? LIMIT 1`,
+      WHERE b.workspace_id = ?
+      ORDER BY b.created_at ASC, b.installation_id ASC`,
     workspaceId,
   );
 }
 
-async function assertActiveBinding(env: Env, principal: Pick<PlexusPrincipal, "workspaceId">): Promise<InstallationBindingRow> {
-  const binding = await getBinding(env, principal.workspaceId);
+async function getBinding(env: Env, workspaceId: string, installationId: number): Promise<InstallationBindingRow | null> {
+  return queryFirst<InstallationBindingRow>(
+    database(env),
+    `SELECT b.*, f.account_login, f.account_type, f.repository_selection
+       FROM github_workspace_installations b
+       JOIN github_installation_facts f ON f.installation_id = b.installation_id
+      WHERE b.workspace_id = ? AND b.installation_id = ? LIMIT 1`,
+    workspaceId,
+    installationId,
+  );
+}
+
+function assertBindingIsActive(env: Env, binding: InstallationBindingRow): InstallationBindingRow {
   if (!binding) throw new GithubControlPlaneError("github_unconfigured", "No GitHub App installation is connected to this workspace.", 409);
   if (binding.repository_selection !== "selected") throw new GithubControlPlaneError("github_repository_selection_forbidden", "GitHub App access to all repositories is forbidden.", 403);
   if (binding.state === "suspended") throw new GithubControlPlaneError("github_suspended", "The workspace GitHub App installation is suspended.", 409);
   if (binding.state !== "active") throw new GithubControlPlaneError("github_forbidden", "The workspace GitHub App installation is revoked.", 403);
-  assertExpectedOrganization(githubEnrollmentPolicy(env), binding);
+  assertAllowedInstallationTarget(githubInstallationPolicy(env), binding);
   return binding;
+}
+
+async function assertActiveBinding(env: Env, workspaceId: string, installationId: number): Promise<InstallationBindingRow> {
+  const binding = await getBinding(env, workspaceId, installationId);
+  if (!binding) throw new GithubControlPlaneError("github_unconfigured", "No matching GitHub App installation is connected to this workspace.", 409);
+  return assertBindingIsActive(env, binding);
+}
+
+async function assertActiveBindings(env: Env, workspaceId: string): Promise<InstallationBindingRow[]> {
+  const bindings = (await getBindings(env, workspaceId)).filter((binding) => binding.state === "active");
+  if (bindings.length === 0) throw new GithubControlPlaneError("github_unconfigured", "No active GitHub App installation is connected to this workspace.", 409);
+  return bindings.map((binding) => assertBindingIsActive(env, binding));
 }
 
 async function ensureActiveAdmin(env: Env, principal: Pick<PlexusPrincipal, "identityId" | "workspaceId">): Promise<void> {
@@ -318,7 +375,8 @@ async function upsertWorkspaceActor(
 export async function reconcileBinding(env: Env, nonceHash: string): Promise<boolean> {
   const db = database(env);
   const state = await queryFirst<ConnectionStateRow>(db, "SELECT * FROM github_connection_states WHERE nonce_hash = ? LIMIT 1", nonceHash);
-  if (!state?.oauth_user_id || !state.oauth_login || !state.untrusted_installation_id || state.status === "rejected" || state.status === "expired") return false;
+  if (!state?.oauth_user_id || !state.oauth_login || !state.untrusted_installation_id || !state.target_account_id ||
+    !state.target_account_login || !state.target_account_type || state.status === "rejected" || state.status === "expired") return false;
   await ensureCallbackActorStillAdmin(env, { workspace: state.workspace_id, actor: state.plexus_actor_id });
   const fact = await queryFirst<{
     installation_id: number;
@@ -342,10 +400,22 @@ export async function reconcileBinding(env: Env, nonceHash: string): Promise<boo
     await execute(db, "UPDATE github_connection_states SET status = 'rejected', updated_at = ? WHERE nonce_hash = ?", now(), nonceHash);
     throw new GithubControlPlaneError("github_actor_mismatch", "OAuth actor does not match the signed installation webhook sender.", 403);
   }
-  const policy = githubEnrollmentPolicy(env);
+  const installationPolicy = githubInstallationPolicy(env);
+  const actorPolicy = githubActorPolicy(env);
   try {
-    assertExpectedOrganization(policy, fact);
-    assertAllowedGithubActor(policy, { id: state.oauth_user_id, login: state.oauth_login });
+    if (fact.account_type !== "Organization" && fact.account_type !== "User") {
+      throw new GithubControlPlaneError("github_installation_account_forbidden", "GitHub App installation account type is invalid.", 403);
+    }
+    assertAllowedInstallationTarget(installationPolicy, {
+      account_id: fact.account_id,
+      account_login: fact.account_login,
+      account_type: fact.account_type,
+    });
+    assertAllowedGithubActor(actorPolicy, { id: state.oauth_user_id, login: state.oauth_login });
+    if (fact.account_id !== state.target_account_id || fact.account_type !== state.target_account_type ||
+      fact.account_login.toLowerCase() !== state.target_account_login.toLowerCase()) {
+      throw new GithubControlPlaneError("github_installation_target_mismatch", "Signed installation account does not match the selected connection target.", 409);
+    }
   } catch (error) {
     await execute(db, "UPDATE github_connection_states SET status = 'rejected', updated_at = ? WHERE nonce_hash = ?", now(), nonceHash);
     throw error;
@@ -369,10 +439,10 @@ export async function reconcileBinding(env: Env, nonceHash: string): Promise<boo
   await execute(
     db,
     `INSERT INTO github_workspace_installations
-       (workspace_id, installation_id, connected_by_identity_id, verified_github_user_id, verified_github_login,
+       (workspace_id, installation_id, account_id, connected_by_identity_id, verified_github_user_id, verified_github_login,
         connection_nonce_hash, state, created_at, updated_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-     ON CONFLICT(workspace_id) DO UPDATE SET
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(workspace_id, account_id) DO UPDATE SET
        installation_id = excluded.installation_id,
        connected_by_identity_id = excluded.connected_by_identity_id,
        verified_github_user_id = excluded.verified_github_user_id,
@@ -382,6 +452,7 @@ export async function reconcileBinding(env: Env, nonceHash: string): Promise<boo
        updated_at = excluded.updated_at`,
     state.workspace_id,
     fact.installation_id,
+    fact.account_id,
     state.plexus_actor_id,
     state.oauth_user_id,
     state.oauth_login,
@@ -401,19 +472,19 @@ export async function handleGithubConnection(env: Env, principal: PlexusPrincipa
     if (!githubConfigurationPresent(env)) {
       return jsonOk({ status: "unconfigured" as const });
     }
-    const binding = await getBinding(env, principal!.workspaceId);
-    if (binding) {
-      let expectedOrganization = true;
-      try {
-        assertExpectedOrganization(githubEnrollmentPolicy(env), binding);
-      } catch (error) {
-        if (error instanceof GithubControlPlaneError) expectedOrganization = false;
-        else throw error;
-      }
-      const status = !expectedOrganization || binding.repository_selection !== "selected"
-        ? "forbidden"
-        : binding.state === "active" ? "connected" : binding.state === "suspended" ? "suspended" : "forbidden";
-      return jsonOk({ status, installationId: binding.installation_id, account: { id: binding.account_id, login: binding.account_login, type: binding.account_type } });
+    const installationPolicy = githubInstallationPolicy(env);
+    const bindings = await getBindings(env, principal!.workspaceId);
+    const installations = bindings.map((binding) => {
+      const allowed = isAllowedInstallationTarget(installationPolicy, binding) && binding.repository_selection === "selected";
+      const status = !allowed ? "forbidden" as const
+        : binding.state === "active" ? "connected" as const
+          : binding.state === "suspended" ? "suspended" as const : "forbidden" as const;
+      return { installationId: binding.installation_id, status, account: installationTargetOf(binding) };
+    });
+    if (installations.length > 0) {
+      const status = installations.some((installation) => installation.status === "connected") ? "connected" as const
+        : installations.some((installation) => installation.status === "suspended") ? "suspended" as const : "forbidden" as const;
+      return jsonOk({ status, installations, allowedTargets: installationPolicy.allowedTargets });
     }
     const pending = await queryFirst<{ expires_at: number }>(
       database(env),
@@ -421,21 +492,26 @@ export async function handleGithubConnection(env: Env, principal: PlexusPrincipa
       principal!.workspaceId,
       Math.floor(Date.now() / 1000),
     );
-    return jsonOk({ status: pending ? "pending" as const : "unconfigured" as const });
+    return jsonOk({ status: pending ? "pending" as const : "unconfigured" as const, installations, allowedTargets: installationPolicy.allowedTargets });
   } catch (error) {
     return controlPlaneError(error);
   }
 }
 
-export async function handleGithubConnectStart(env: Env, principal: PlexusPrincipal | null): Promise<Response> {
+export async function handleGithubConnectStart(env: Env, request: Request, principal: PlexusPrincipal | null): Promise<Response> {
   const denied = requireAdmin(principal);
   if (denied) return denied;
   try {
     const db = database(env);
+    const body = await parseJsonObject(request);
+    const accountId = Number(body.accountId);
+    const policy = githubInstallationPolicy(env);
+    const target = Number.isSafeInteger(accountId) && accountId > 0 ? policy.allowedTargetById.get(accountId) : undefined;
+    if (!target) throw new GithubControlPlaneError("github_installation_target_required", "An exact allowlisted numeric accountId is required.", 400);
     const nonce = randomNonce();
     const nonceHash = await sha256Hex(nonce);
     const expiresAt = Math.floor(Date.now() / 1000) + 600;
-    const state = await signConnectState({ workspace: principal!.workspaceId, actor: principal!.identityId, nonce, exp: expiresAt }, stateSecret(env));
+    const state = await signConnectState({ workspace: principal!.workspaceId, actor: principal!.identityId, nonce, exp: expiresAt, target }, stateSecret(env));
     const authorizeUrl = buildOauthAuthorizeUrl(env, state);
     const timestamp = now();
     await execute(
@@ -448,24 +524,27 @@ export async function handleGithubConnectStart(env: Env, principal: PlexusPrinci
     await execute(
       db,
       `INSERT INTO github_connection_states
-       (nonce_hash, workspace_id, plexus_actor_id, expires_at, status, created_at, updated_at)
-       VALUES (?, ?, ?, ?, 'pending_oauth', ?, ?)`,
+       (nonce_hash, workspace_id, plexus_actor_id, expires_at, target_account_id, target_account_login,
+        target_account_type, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 'pending_oauth', ?, ?)`,
       nonceHash,
       principal!.workspaceId,
       principal!.identityId,
       expiresAt,
+      target.id,
+      target.login,
+      target.type,
       timestamp,
       timestamp,
     );
-    return jsonOk({ status: "pending" as const, authorizeUrl }, { status: 201 });
+    return jsonOk({ status: "pending" as const, authorizeUrl, target }, { status: 201 });
   } catch (error) {
     return controlPlaneError(error);
   }
 }
 
-function actorPolicyPayload(policy: GithubEnrollmentPolicy) {
+function actorPolicyPayload(policy: GithubActorPolicy) {
   return {
-    organization: { id: policy.organizationId, login: policy.organization },
     allowedLogins: policy.allowedActors.map((actor) => actor.login),
   };
 }
@@ -475,18 +554,14 @@ export async function handleGithubActor(env: Env, principal: PlexusPrincipal | n
   if (denied) return denied;
   try {
     if (!githubConfigurationPresent(env)) return jsonOk({ status: "unconfigured" as const });
-    const policy = githubEnrollmentPolicy(env);
+    const policy = githubActorPolicy(env);
     const policyPayload = actorPolicyPayload(policy);
-    const binding = await getBinding(env, principal!.workspaceId);
-    if (!binding) return jsonOk({ status: "unconfigured" as const, ...policyPayload });
-    if (binding.repository_selection !== "selected" || binding.state !== "active") {
+    const bindings = await getBindings(env, principal!.workspaceId);
+    if (bindings.length === 0) return jsonOk({ status: "unconfigured" as const, ...policyPayload });
+    const activeBindings = bindings.filter((binding) => binding.state === "active" && binding.repository_selection === "selected" &&
+      isAllowedInstallationTarget(githubInstallationPolicy(env), binding));
+    if (activeBindings.length === 0) {
       return jsonOk({ status: "forbidden" as const, ...policyPayload });
-    }
-    try {
-      assertExpectedOrganization(policy, binding);
-    } catch (error) {
-      if (error instanceof GithubControlPlaneError) return jsonOk({ status: "forbidden" as const, ...policyPayload });
-      throw error;
     }
     const actor = await getWorkspaceActor(env, principal!.workspaceId, principal!.identityId);
     if (actor) {
@@ -517,8 +592,8 @@ export async function handleGithubActorEnrollStart(env: Env, principal: PlexusPr
   if (denied) return denied;
   try {
     await ensureActiveAdmin(env, principal!);
-    await assertActiveBinding(env, principal!);
-    const policy = githubEnrollmentPolicy(env);
+    await assertActiveBindings(env, principal!.workspaceId);
+    const policy = githubActorPolicy(env);
     const nonce = randomNonce();
     const nonceHash = await sha256Hex(nonce);
     const expiresAt = Math.floor(Date.now() / 1000) + 600;
@@ -586,9 +661,9 @@ async function handleGithubActorCallback(
   );
   if (changes !== 1) throw new GithubControlPlaneError("github_state_consumed", "GitHub actor enrollment state was already consumed.", 409);
   try {
-    const policy = githubEnrollmentPolicy(env);
-    const binding = await assertActiveBinding(env, { workspaceId: state.workspace });
-    const user = await new GithubAppClient(env).exchangeOauthCode(code, binding.installation_id);
+    const policy = githubActorPolicy(env);
+    const bindings = await assertActiveBindings(env, state.workspace);
+    const user = await new GithubAppClient(env).exchangeOauthCode(code, bindings.map((binding) => binding.installation_id));
     assertAllowedGithubActor(policy, user);
     await upsertWorkspaceActor(env, {
       workspaceId: state.workspace,
@@ -629,6 +704,12 @@ export async function handleGithubCallback(env: Env, _request: Request, url: URL
       nonceHash,
     );
     if (actorState) return await handleGithubActorCallback(env, url, state, nonceHash);
+    const connectionState = await queryFirst<ConnectionStateRow>(db, "SELECT * FROM github_connection_states WHERE nonce_hash = ? LIMIT 1", nonceHash);
+    if (!state.target || !connectionState || connectionState.workspace_id !== state.workspace || connectionState.plexus_actor_id !== state.actor ||
+      connectionState.target_account_id !== state.target.id || connectionState.target_account_type !== state.target.type ||
+      connectionState.target_account_login?.toLowerCase() !== state.target.login.toLowerCase()) {
+      throw new GithubControlPlaneError("github_installation_target_mismatch", "GitHub connection state is not bound to the selected installation account.", 409);
+    }
     const installationParam = url.searchParams.get("installation_id");
     const installationId = installationParam && /^\d+$/.test(installationParam) ? Number(installationParam) : null;
     if (installationParam && (!installationId || !Number.isSafeInteger(installationId))) {
@@ -670,7 +751,7 @@ export async function handleGithubCallback(env: Env, _request: Request, url: URL
       );
       if (changes === 1) {
         try {
-          const policy = githubEnrollmentPolicy(env);
+          const policy = githubActorPolicy(env);
           const user = await new GithubAppClient(env).exchangeOauthCode(code);
           assertAllowedGithubActor(policy, user);
           await execute(
@@ -698,6 +779,7 @@ export async function handleGithubCallback(env: Env, _request: Request, url: URL
     if (row?.oauth_user_id && !row.untrusted_installation_id) {
       const installationUrl = new URL(buildInstallationUrl(env));
       installationUrl.searchParams.set("state", stateValue);
+      installationUrl.searchParams.set("target_id", String(state.target.id));
       return Response.redirect(installationUrl.toString(), 302);
     }
     return jsonOk({ status: "pending" as const });
@@ -799,11 +881,22 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
     const installationId = Number(installation?.id);
     const senderId = Number(sender?.id);
     const accountId = Number(account?.id);
+    const accountType = account?.type;
     const repositorySelection = installation?.repository_selection;
     if (!Number.isSafeInteger(installationId) || installationId <= 0 || !Number.isSafeInteger(senderId) || senderId <= 0 ||
       !Number.isSafeInteger(accountId) || accountId <= 0 || !account?.login || !sender?.login ||
+      (accountType !== "Organization" && accountType !== "User") ||
       (repositorySelection !== "selected" && repositorySelection !== "all")) {
       throw new GithubControlPlaneError("github_webhook_payload_invalid", "Signed installation facts are incomplete.", 400);
+    }
+    const accountTarget: GithubInstallationAccountTarget = { id: accountId, login: String(account.login), type: accountType };
+    if (!isAllowedInstallationTarget(githubInstallationPolicy(env), {
+      account_id: accountTarget.id,
+      account_login: accountTarget.login,
+      account_type: accountTarget.type,
+    })) {
+      await execute(db, "UPDATE github_webhook_deliveries SET processed_at = ?, result = 'ignored' WHERE delivery_id = ?", now(), deliveryId);
+      return jsonOk({ status: "ignored" as const });
     }
     const action = String(payload.action ?? "");
     const allowedActions = eventName === "installation"
@@ -826,7 +919,7 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
            last_actor_id = excluded.last_actor_id, last_actor_login = excluded.last_actor_login,
            repository_selection = excluded.repository_selection, last_delivery_id = excluded.last_delivery_id,
            observed_at = excluded.observed_at, updated_at = excluded.updated_at`,
-        installationId, accountId, String(account.login), String(account.type ?? "Organization"),
+        installationId, accountId, String(account.login), accountType,
         senderId, String(sender.login), senderId, String(sender.login),
         repositorySelection, deliveryId, observedAt, observedAt,
       );
@@ -840,7 +933,7 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
            account_id = ?, account_login = ?, account_type = ?, last_actor_id = ?, last_actor_login = ?,
            repository_selection = ?, state = ?, last_delivery_id = ?, observed_at = ?, updated_at = ?
          WHERE installation_id = ?`,
-        accountId, String(account.login), String(account.type ?? "Organization"), senderId, String(sender.login),
+        accountId, String(account.login), accountType, senderId, String(sender.login),
         repositorySelection, factState, deliveryId, observedAt, observedAt, installationId,
       );
     }
@@ -960,17 +1053,20 @@ export async function handleGithubRepositories(env: Env, principal: PlexusPrinci
   const denied = requireAdmin(principal);
   if (denied) return denied;
   try {
-    const binding = await assertActiveBinding(env, principal!);
-    const repositories = await discoverRepositories(env, binding);
+    const bindings = await assertActiveBindings(env, principal!.workspaceId);
+    const repositories = (await Promise.all(bindings.map(async (binding) => ({ binding, repositories: await discoverRepositories(env, binding) }))))
+      .flatMap(({ binding, repositories: installationRepositories }) => installationRepositories.map((repo) => ({ binding, repo })));
     return jsonOk({
       status: "connected" as const,
-      repositories: repositories.map((repo) => ({
+      repositories: repositories.map(({ binding, repo }) => ({
         id: repo.id,
         name: repo.name,
         fullName: repo.full_name,
         private: repo.private,
         defaultBranch: repo.default_branch,
         owner: repo.owner.login,
+        installationId: binding.installation_id,
+        account: installationTargetOf(binding),
       })),
     });
   } catch (error) {
@@ -1002,11 +1098,14 @@ export async function handleGithubRepoVerify(env: Env, request: Request, project
   if (denied) return denied;
   try {
     const body = await parseJsonObject(request);
+    const installationId = Number(body.installationId);
     const repositoryId = Number(body.repositoryId);
-    if (!Number.isSafeInteger(repositoryId) || repositoryId <= 0) throw new GithubControlPlaneError("github_repository_id_required", "numeric repositoryId is required.", 400);
+    if (!Number.isSafeInteger(installationId) || installationId <= 0 || !Number.isSafeInteger(repositoryId) || repositoryId <= 0) {
+      throw new GithubControlPlaneError("github_repository_id_required", "numeric installationId and repositoryId are required.", 400);
+    }
     await assertProjectWorkspace(env, projectId, principal!.workspaceId);
-    const binding = await assertActiveBinding(env, principal!);
-    const authority = await getRepositoryAuthority(env, principal!.workspaceId, binding.installation_id, repositoryId);
+    const binding = await assertActiveBinding(env, principal!.workspaceId, installationId);
+    const authority = await getRepositoryAuthority(env, principal!.workspaceId, installationId, repositoryId);
     const client = new GithubAppClient(env);
     const token = await client.createInstallationToken(binding.installation_id, [repositoryId], "metadata");
     const repo = await client.request<GithubRepository>(token.token, `/repos/${encodeURIComponent(authority.owner_login)}/${encodeURIComponent(authority.name)}`);
@@ -1024,7 +1123,7 @@ export async function handleGithubRepoVerify(env: Env, request: Request, project
          verified_by_identity_id = excluded.verified_by_identity_id, verified_at = excluded.verified_at, updated_at = excluded.updated_at`,
       projectId,
       principal!.workspaceId,
-      binding.installation_id,
+      installationId,
       repo.id,
       repo.owner.login,
       repo.name,
@@ -1036,7 +1135,17 @@ export async function handleGithubRepoVerify(env: Env, request: Request, project
     return jsonOk({
       status: "verified" as const,
       repoVerifiedAt: verifiedAt,
-      repository: { id: repo.id, owner: repo.owner.login, name: repo.name, fullName: repo.full_name, private: repo.private, defaultBranch: repo.default_branch, verifiedAt },
+      repository: {
+        id: repo.id,
+        owner: repo.owner.login,
+        name: repo.name,
+        fullName: repo.full_name,
+        private: repo.private,
+        defaultBranch: repo.default_branch,
+        verifiedAt,
+        installationId: binding.installation_id,
+        account: installationTargetOf(binding),
+      },
     });
   } catch (error) {
     return controlPlaneError(error);
@@ -1115,9 +1224,8 @@ export async function handleGithubActivitySync(env: Env, request: Request, proje
   try {
     const range = parseActivityRange(await parseJsonObject(request));
     await assertProjectWorkspace(env, projectId, principal!.workspaceId);
-    const binding = await assertActiveBinding(env, principal!);
     const verified = await getVerifiedRepository(env, projectId, principal!.workspaceId);
-    if (verified.installation_id !== binding.installation_id) throw new GithubControlPlaneError("github_repository_forbidden", "Verified repository does not belong to the active workspace installation.", 403);
+    const binding = await assertActiveBinding(env, principal!.workspaceId, verified.installation_id);
     const client = new GithubAppClient(env);
     const token = await client.createInstallationToken(binding.installation_id, [verified.repository_id], "activity");
     const repoPath = `/repos/${encodeURIComponent(verified.owner_login)}/${encodeURIComponent(verified.name)}`;
@@ -1283,12 +1391,12 @@ export async function handleGithubPullRequest(env: Env, request: Request, projec
     const files = validateWriteFiles(body.files);
     await assertProjectWorkspace(env, projectId, principal!.workspaceId);
     await ensureActiveAdmin(env, principal!);
-    const binding = await assertActiveBinding(env, principal!);
     const actor = await getWorkspaceActor(env, principal!.workspaceId, principal!.identityId);
     if (!actor) throw new GithubControlPlaneError("github_actor_not_verified", "Current Plexus administrator has not verified a GitHub identity.", 403);
-    assertAllowedGithubActor(githubEnrollmentPolicy(env), { id: actor.github_user_id, login: actor.github_login });
+    assertAllowedGithubActor(githubActorPolicy(env), { id: actor.github_user_id, login: actor.github_login });
     const verified = await getVerifiedRepository(env, projectId, principal!.workspaceId);
-    if (verified.repository_id !== repositoryId || verified.installation_id !== binding.installation_id) throw new GithubControlPlaneError("github_repository_forbidden", "Repository is not the verified project repository.", 403);
+    if (verified.repository_id !== repositoryId) throw new GithubControlPlaneError("github_repository_forbidden", "Repository is not the verified project repository.", 403);
+    const binding = await assertActiveBinding(env, principal!.workspaceId, verified.installation_id);
     const operationKey = await sha256Hex(JSON.stringify({ workspace: principal!.workspaceId, actor: principal!.identityId, projectId, repositoryId, baseSha, title, pullBody, commitMessage: requestedCommitMessage, files }));
     const branch = `plexus/${safeBranchPart(projectId)}-${operationKey.slice(0, 12)}`;
     if (branch === verified.default_branch) throw new GithubControlPlaneError("github_default_branch_forbidden", "Default branch writes are forbidden.", 403);

--- a/cloudflare/worker/src/routes/github.ts
+++ b/cloudflare/worker/src/routes/github.ts
@@ -291,9 +291,12 @@ async function assertActiveBinding(env: Env, workspaceId: string, installationId
 }
 
 async function assertActiveBindings(env: Env, workspaceId: string): Promise<InstallationBindingRow[]> {
-  const bindings = (await getBindings(env, workspaceId)).filter((binding) => binding.state === "active");
+  const activeBindings = (await getBindings(env, workspaceId)).filter((binding) => binding.state === "active");
+  if (activeBindings.length === 0) throw new GithubControlPlaneError("github_unconfigured", "No active GitHub App installation is connected to this workspace.", 409);
+  const policy = githubInstallationPolicy(env);
+  const bindings = activeBindings.filter((binding) => binding.repository_selection === "selected" && isAllowedInstallationTarget(policy, binding));
   if (bindings.length === 0) throw new GithubControlPlaneError("github_unconfigured", "No active GitHub App installation is connected to this workspace.", 409);
-  return bindings.map((binding) => assertBindingIsActive(env, binding));
+  return bindings;
 }
 
 async function ensureActiveAdmin(env: Env, principal: Pick<PlexusPrincipal, "identityId" | "workspaceId">): Promise<void> {

--- a/cloudflare/worker/src/routes/v1.ts
+++ b/cloudflare/worker/src/routes/v1.ts
@@ -213,7 +213,7 @@ export async function handleV1Request(request: Request, env: Env, url: URL): Pro
     return handleGithubConnection(env, plexusPrincipal);
   }
   if (method === "POST" && pathname === "/v1/github/connect/start") {
-    return handleGithubConnectStart(env, plexusPrincipal);
+    return handleGithubConnectStart(env, request, plexusPrincipal);
   }
   if (method === "GET" && pathname === "/v1/github/actor") {
     return handleGithubActor(env, plexusPrincipal);

--- a/cloudflare/worker/wrangler.jsonc
+++ b/cloudflare/worker/wrangler.jsonc
@@ -18,8 +18,7 @@
     // use `wrangler rollback`, set them to "", or delete in the dashboard.
     "TF_ACCESS_TEAM_DOMAIN": "red-queen-4dfa.cloudflareaccess.com",
     "TF_ACCESS_AUD": "5695e8409cd4e838eaaef4de4995541dae4f31a2773945ea67f136800977c200,d3892b5d2a62027029b09b2fd015a9e8074d5efb38c443099f803517cb3feb51",
-    "TF_GITHUB_EXPECTED_ORG": "thoughtseed-labs",
-    "TF_GITHUB_EXPECTED_ORG_ID": "65741640",
+    "TF_GITHUB_ALLOWED_INSTALLATION_ACCOUNTS": "Organization:thoughtseed-labs:65741640,User:Sheshiyer:7611727,User:psychon7:47470954",
     "TF_GITHUB_ALLOWED_ACTORS": "Sheshiyer:7611727,psychon7:47470954",
     "TF_INTEGRATION_CONFIG_JSON": "{\"github\":{\"repos\":[{\"repo\":\"Sheshiyer/parkarea-aleph\",\"displayName\":\"ParkArea Phase 2 - Germany Launch\",\"clientName\":\"ParkArea\",\"defaultMilestoneNumber\":1,\"enabled\":true}]},\"huly\":{\"mirrorMode\":\"read_only\",\"mirrorEnabled\":true},\"slack\":{},\"clockify\":{}}",
     // Temporary internal shared secret for m2m (parity, Hermes) bypassing CF Access service token issues on this Worker route.


### PR DESCRIPTION
## Summary

- support separate GitHub App installations for thoughtseed-labs, Sheshiyer, and psychon7 through exact type, login, and numeric-ID policy
- add migration 0014 for multiple account-scoped workspace bindings while preserving the existing installation
- bind connection state to the selected owner and ignore signed webhooks from non-allowlisted accounts before installation facts
- aggregate repositories across active installations and persist the chosen installation for verification, activity, and guarded writes
- keep founder actor enrollment separate and prove both founders can enroll through any active workspace installation

## Verification

- pnpm check
- GitHub route and migration suite: 13 files, 125 tests
- real SQLite fresh-schema rehearsal and 0013-to-0014 preservation rehearsal
- git diff --check

## Coordination boundary

This is the Worker half of the coordinated Plexus multi-owner change. Do not deploy it alone before the matching Plexus client contract lands. Source completion does not claim GitHub App registration, owner installation, production secrets, D1 production migration, deployment, or live founder OAuth proof.
