### PR TITLE
chore(github): configure production app identity

### DIFF
--- a/cloudflare/worker/wrangler.jsonc
+++ b/cloudflare/worker/wrangler.jsonc
@@ -18,6 +18,10 @@
     // use `wrangler rollback`, set them to "", or delete in the dashboard.
     "TF_ACCESS_TEAM_DOMAIN": "red-queen-4dfa.cloudflareaccess.com",
     "TF_ACCESS_AUD": "5695e8409cd4e838eaaef4de4995541dae4f31a2773945ea67f136800977c200,d3892b5d2a62027029b09b2fd015a9e8074d5efb38c443099f803517cb3feb51",
+    "TF_GITHUB_APP_ID": "4294060",
+    "TF_GITHUB_APP_SLUG": "thoughtseed-plexus",
+    "TF_GITHUB_APP_CLIENT_ID": "Iv23liFIWZM8aAmYUpar",
+    "TF_GITHUB_APP_CALLBACK_URL": "https://plexus-api.thoughtseed.space/v1/github/callback",
     "TF_GITHUB_ALLOWED_INSTALLATION_ACCOUNTS": "Organization:thoughtseed-labs:65741640,User:Sheshiyer:7611727,User:psychon7:47470954",
     "TF_GITHUB_ALLOWED_ACTORS": "Sheshiyer:7611727,psychon7:47470954",
     "TF_INTEGRATION_CONFIG_JSON": "{\"github\":{\"repos\":[{\"repo\":\"Sheshiyer/parkarea-aleph\",\"displayName\":\"ParkArea Phase 2 - Germany Launch\",\"clientName\":\"ParkArea\",\"defaultMilestoneNumber\":1,\"enabled\":true}]},\"huly\":{\"mirrorMode\":\"read_only\",\"mirrorEnabled\":true},\"slack\":{},\"clockify\":{}}",


### PR DESCRIPTION
## Summary

- pin the production GitHub App ID, slug, and client ID
- set the production OAuth callback URL
- retain the exact three-owner installation and founder policies

## Verification

- pnpm -C cloudflare/worker check
- pnpm -C cloudflare/worker test (127 passed)
- git diff --check

Secrets remain outside source and will be entered directly with Wrangler.