### PR TITLE
fix(github): harden OAuth callback exchange

### DIFF
--- a/cloudflare/worker/src/lib/github-app.test.ts
+++ b/cloudflare/worker/src/lib/github-app.test.ts
@@ -66,6 +66,33 @@ describe("GitHub App cryptographic boundary", () => {
     await expect(verifyWebhookSignature('{"ok":false}', signature, secret)).resolves.toBe(false);
   });
 
+  it("exchanges OAuth codes using the documented form encoding and never returns the user token", async () => {
+    let tokenRequest: RequestInit | undefined;
+    const mockedFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === "https://github.com/login/oauth/access_token") {
+        tokenRequest = init;
+        return new Response(JSON.stringify({ access_token: "ephemeral-user-token" }));
+      }
+      if (String(input) === "https://api.github.com/user") {
+        expect(new Headers(init?.headers).get("authorization")).toBe("Bearer ephemeral-user-token");
+        return new Response(JSON.stringify({ id: 7611727, login: "Sheshiyer" }));
+      }
+      throw new Error(`unexpected fetch ${String(input)}`);
+    }) as unknown as typeof fetch;
+
+    const user = await new GithubAppClient(makeEnv(), mockedFetch).exchangeOauthCode("one-time-code");
+    const body = new URLSearchParams(String(tokenRequest?.body));
+    expect(new Headers(tokenRequest?.headers).get("content-type")).toBe("application/x-www-form-urlencoded");
+    expect(Object.fromEntries(body)).toEqual({
+      client_id: "Iv1.test",
+      client_secret: "client-secret",
+      code: "one-time-code",
+      redirect_uri: "https://worker.test/v1/github/callback",
+    });
+    expect(user).toEqual({ id: 7611727, login: "Sheshiyer" });
+    expect(JSON.stringify(user)).not.toContain("ephemeral-user-token");
+  });
+
   it("narrows write tokens to numeric repositories and least permissions", async () => {
     let requestBody: Record<string, unknown> | null = null;
     let apiVersion = "";

--- a/cloudflare/worker/src/lib/github-app.ts
+++ b/cloudflare/worker/src/lib/github-app.ts
@@ -236,6 +236,19 @@ async function responseJson<T>(response: Response, code: string): Promise<T> {
   }
 }
 
+async function githubFetch(
+  fetchImpl: typeof fetch,
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  code: string,
+): Promise<Response> {
+  try {
+    return await fetchImpl(input, init);
+  } catch {
+    throw new GithubControlPlaneError(code, "GitHub request could not be completed.", 502, true);
+  }
+}
+
 export class GithubAppClient {
   constructor(
     private readonly env: Env,
@@ -260,21 +273,22 @@ export class GithubAppClient {
 
   async exchangeOauthCode(code: string, requiredInstallationIds?: number[]): Promise<GithubUser> {
     const config = requireGithubAppEnv(this.env);
-    const tokenResponse = await this.fetchImpl("https://github.com/login/oauth/access_token", {
+    const tokenBody = new URLSearchParams({
+      client_id: config.TF_GITHUB_APP_CLIENT_ID,
+      client_secret: config.TF_GITHUB_APP_CLIENT_SECRET,
+      code,
+      redirect_uri: config.TF_GITHUB_APP_CALLBACK_URL,
+    });
+    const tokenResponse = await githubFetch(this.fetchImpl, "https://github.com/login/oauth/access_token", {
       method: "POST",
-      headers: { accept: "application/json", "content-type": "application/json" },
-      body: JSON.stringify({
-        client_id: config.TF_GITHUB_APP_CLIENT_ID,
-        client_secret: config.TF_GITHUB_APP_CLIENT_SECRET,
-        code,
-        redirect_uri: config.TF_GITHUB_APP_CALLBACK_URL,
-      }),
-    });
-    const tokenBody = await responseJson<{ access_token?: string; error?: string }>(tokenResponse, "github_oauth_exchange_failed");
-    if (!tokenBody.access_token) throw new GithubControlPlaneError("github_oauth_exchange_failed", "GitHub OAuth did not return an access token.", 502);
-    const userResponse = await this.fetchImpl(`${GITHUB_API}/user`, {
-      headers: this.headers(tokenBody.access_token),
-    });
+      headers: { accept: "application/json", "content-type": "application/x-www-form-urlencoded" },
+      body: tokenBody.toString(),
+    }, "github_oauth_exchange_failed");
+    const tokenPayload = await responseJson<{ access_token?: string; error?: string }>(tokenResponse, "github_oauth_exchange_failed");
+    if (!tokenPayload.access_token) throw new GithubControlPlaneError("github_oauth_exchange_failed", "GitHub OAuth did not return an access token.", 502);
+    const userResponse = await githubFetch(this.fetchImpl, `${GITHUB_API}/user`, {
+      headers: this.headers(tokenPayload.access_token),
+    }, "github_oauth_identity_failed");
     const user = await responseJson<Pick<GithubUser, "id" | "login">>(userResponse, "github_oauth_identity_failed");
     if (!Number.isSafeInteger(user.id) || !user.login) throw new GithubControlPlaneError("github_oauth_identity_failed", "GitHub OAuth identity is invalid.", 502);
     if (requiredInstallationIds !== undefined) {
@@ -284,9 +298,9 @@ export class GithubAppClient {
       }
       let installationAccessible = false;
       for (let page = 1; page <= 10; page += 1) {
-        const installationsResponse = await this.fetchImpl(`${GITHUB_API}/user/installations?per_page=100&page=${page}`, {
-          headers: this.headers(tokenBody.access_token),
-        });
+        const installationsResponse = await githubFetch(this.fetchImpl, `${GITHUB_API}/user/installations?per_page=100&page=${page}`, {
+          headers: this.headers(tokenPayload.access_token),
+        }, "github_oauth_installations_failed");
         const installations = await responseJson<{ installations?: Array<{ id?: number }> }>(
           installationsResponse,
           "github_oauth_installations_failed",
@@ -327,11 +341,11 @@ export class GithubAppClient {
           : { metadata: "read" };
     const tokenRequest: Record<string, unknown> = { permissions };
     if (repositoryIds !== null) tokenRequest.repository_ids = [...new Set(repositoryIds)];
-    const response = await this.fetchImpl(`${GITHUB_API}/app/installations/${installationId}/access_tokens`, {
+    const response = await githubFetch(this.fetchImpl, `${GITHUB_API}/app/installations/${installationId}/access_tokens`, {
       method: "POST",
       headers: this.headers(await this.createAppJwt()),
       body: JSON.stringify(tokenRequest),
-    });
+    }, "github_installation_token_failed");
     const body = await responseJson<{ token?: string; expires_at?: string }>(response, "github_installation_token_failed");
     const expiresAtMs = Date.parse(body.expires_at ?? "");
     const nowMs = Date.now();
@@ -342,18 +356,18 @@ export class GithubAppClient {
   }
 
   async request<T>(token: string, path: string, init: RequestInit = {}): Promise<T> {
-    const response = await this.fetchImpl(`${GITHUB_API}${path}`, {
+    const response = await githubFetch(this.fetchImpl, `${GITHUB_API}${path}`, {
       ...init,
       headers: { ...this.headers(token), ...(init.body ? { "content-type": "application/json" } : {}), ...init.headers },
-    });
+    }, "github_api_failed");
     return responseJson<T>(response, "github_api_failed");
   }
 
   async requestOptional<T>(token: string, path: string, init: RequestInit = {}): Promise<T | null> {
-    const response = await this.fetchImpl(`${GITHUB_API}${path}`, {
+    const response = await githubFetch(this.fetchImpl, `${GITHUB_API}${path}`, {
       ...init,
       headers: { ...this.headers(token), ...(init.body ? { "content-type": "application/json" } : {}), ...init.headers },
-    });
+    }, "github_api_failed");
     if (response.status === 404) return null;
     return responseJson<T>(response, "github_api_failed");
   }

--- a/cloudflare/worker/src/routes/__tests__/github.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/github.test.ts
@@ -325,6 +325,10 @@ function connectionFlowDb(nonceHash: string) {
             state.oauth_user_id = args[0]; state.oauth_login = args[1]; state.oauth_verified_at = args[2]; state.status = "oauth_verified";
             return { success: true, meta: { changes: 1 } };
           }
+          if (sql.includes("SET status = 'rejected'")) {
+            state.status = "rejected";
+            return { success: true, meta: { changes: 1 } };
+          }
           if (sql.includes("INSERT INTO github_installation_facts")) {
             fact = { installation_id: args[0], account_id: args[1], account_login: args[2], account_type: args[3], installer_sender_id: args[4], installer_sender_login: args[5], last_actor_id: args[6], last_actor_login: args[7], repository_selection: args[8], state: "active" };
             return { success: true, meta: { changes: 1 } };
@@ -893,6 +897,27 @@ describe("GitHub App routes", () => {
     const replay = await handleGithubCallback(callbackEnv, new Request(callbackUrl), callbackUrl);
     expect(replay.status).toBe(409);
     await expect(replay.json()).resolves.toMatchObject({ error: { code: "github_state_consumed" } });
+    vi.unstubAllGlobals();
+  });
+
+  it("returns a typed retryable error when the GitHub OAuth transport fails", async () => {
+    const nonce = "nonce-oauth-transport";
+    const nonceHash = await sha256Hex(nonce);
+    const fixture = connectionFlowDb(nonceHash);
+    const stateValue = await signConnectState(
+      { workspace: "ws_test", actor: "pid_admin", nonce, exp: Math.floor(Date.now() / 1000) + 600, target: { id: 8, login: "thoughtseed", type: "Organization" } },
+      "s".repeat(32),
+    );
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new TypeError("network unavailable");
+    }));
+    const callbackUrl = new URL(`https://worker.test/v1/github/callback?state=${encodeURIComponent(stateValue)}&code=one-time-code`);
+    const response = await handleGithubCallback(env(fixture.db), new Request(callbackUrl), callbackUrl);
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "github_oauth_exchange_failed", retryable: true },
+    });
+    expect(fixture.state.status).toBe("rejected");
     vi.unstubAllGlobals();
   });
 

--- a/cloudflare/worker/src/routes/github.ts
+++ b/cloudflare/worker/src/routes/github.ts
@@ -128,6 +128,13 @@ function controlPlaneError(error: unknown): Response {
   if (error instanceof GithubControlPlaneError) {
     return jsonError({ code: error.code, message: error.message, retryable: error.retryable }, error.status);
   }
+  const message = error instanceof Error ? error.message : "";
+  console.error("github_control_plane_unexpected", {
+    name: error instanceof Error ? error.name : typeof error,
+    category: /D1|SQLITE|database|bind|constraint/i.test(message)
+      ? "database"
+      : /fetch|network|connect|socket/i.test(message) ? "transport" : "runtime",
+  });
   return jsonError({ code: "github_control_plane_failed", message: "GitHub control-plane operation failed.", retryable: false }, 500);
 }
 


### PR DESCRIPTION
## Summary

- send the GitHub App OAuth code exchange using the documented form encoding
- convert GitHub transport failures into typed retryable control-plane errors
- emit secret-free categories for unexpected callback failures
- add regression coverage for token custody and transport rejection

## Production evidence

The first live owner-connect callback consumed and rejected its one-time state without persisting an OAuth identity, installation fact, repository grant, or workspace binding. This patch keeps that fail-closed behavior while making the boundary diagnosable and retryable.

## Verification

- 129 Worker tests pass
- TypeScript check passes
- git diff --check passes
- independent read-only review found no blocker or P2 issue