### PR TITLE
fix(github): accept post-install callback replay

### DIFF
--- a/cloudflare/worker/src/routes/__tests__/github.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/github.test.ts
@@ -333,6 +333,10 @@ function connectionFlowDb(nonceHash: string) {
             fact = { installation_id: args[0], account_id: args[1], account_login: args[2], account_type: args[3], installer_sender_id: args[4], installer_sender_login: args[5], last_actor_id: args[6], last_actor_login: args[7], repository_selection: args[8], state: "active" };
             return { success: true, meta: { changes: 1 } };
           }
+          if (sql.includes("UPDATE github_installation_facts SET")) {
+            fact = { ...fact, account_id: args[0], account_login: args[1], account_type: args[2], repository_selection: args[5], state: args[6] };
+            return { success: true, meta: { changes: 1 } };
+          }
           if (sql.includes("INSERT INTO github_workspace_installations")) {
             binding = { workspace_id: args[0], installation_id: args[1], account_id: args[2], connected_by_identity_id: args[3], verified_github_user_id: args[4], verified_github_login: args[5], state: args[7] };
             return { success: true, meta: { changes: 1 } };
@@ -348,7 +352,7 @@ function connectionFlowDb(nonceHash: string) {
       return statement;
     },
   };
-  return { db, state, binding: () => binding };
+  return { db, state, binding: () => binding, fact: () => fact, delivery: (id: string) => deliveries.get(id) };
 }
 
 function actorEnrollmentDb(
@@ -919,6 +923,71 @@ describe("GitHub App routes", () => {
     });
     expect(fixture.state.status).toBe("rejected");
     vi.unstubAllGlobals();
+  });
+
+  it("accepts GitHub's post-install callback when it repeats code with an installation id", async () => {
+    const nonce = "nonce-post-install-code";
+    const nonceHash = await sha256Hex(nonce);
+    const fixture = connectionFlowDb(nonceHash);
+    const stateValue = await signConnectState(
+      { workspace: "ws_test", actor: "pid_admin", nonce, exp: Math.floor(Date.now() / 1000) + 600, target: { id: 8, login: "thoughtseed", type: "Organization" } },
+      "s".repeat(32),
+    );
+    const fetcher = vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes("oauth/access_token")) return new Response(JSON.stringify({ access_token: "oauth-token" }));
+      if (String(input).endsWith("/user")) return new Response(JSON.stringify({ id: 77, login: "installer" }));
+      throw new Error(`unexpected fetch ${String(input)}`);
+    });
+    vi.stubGlobal("fetch", fetcher);
+    const oauthCallback = new URL(`https://worker.test/v1/github/callback?state=${encodeURIComponent(stateValue)}&code=one-time-code`);
+    expect((await handleGithubCallback(env(fixture.db), new Request(oauthCallback), oauthCallback)).status).toBe(302);
+
+    const installCallback = new URL(`https://worker.test/v1/github/callback?state=${encodeURIComponent(stateValue)}&code=second-code&installation_id=42&setup_action=install`);
+    const response = await handleGithubCallback(env(fixture.db), new Request(installCallback), installCallback);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ data: { status: "pending" } });
+    expect(fixture.state).toMatchObject({ status: "oauth_verified", untrusted_installation_id: 42, oauth_user_id: 77 });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    fixture.state.status = "bound";
+    const boundReplay = await handleGithubCallback(env(fixture.db), new Request(installCallback), installCallback);
+    expect(boundReplay.status).toBe(409);
+    await expect(boundReplay.json()).resolves.toMatchObject({ error: { code: "github_state_consumed" } });
+    vi.unstubAllGlobals();
+  });
+
+  it("processes installation deletion without trusting sparse repository objects", async () => {
+    const nonceHash = await sha256Hex("nonce-deleted-installation");
+    const fixture = connectionFlowDb(nonceHash);
+    const secret = "webhook-test-secret";
+    const webhookEnv = { ...env(fixture.db), TF_GITHUB_APP_WEBHOOK_SECRET: secret };
+    const created = JSON.stringify({
+      action: "created",
+      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: "selected" },
+      sender: { id: 77, login: "installer" },
+      repositories: [],
+    });
+    const createdResponse = await handleGithubWebhook(webhookEnv, new Request("https://worker.test/v1/github/webhook", {
+      method: "POST",
+      headers: { "x-hub-signature-256": await webhookSignature(created, secret), "x-github-delivery": "delivery-created", "x-github-event": "installation" },
+      body: created,
+    }));
+    expect(createdResponse.status).toBe(200);
+
+    const deleted = JSON.stringify({
+      action: "deleted",
+      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: "selected" },
+      sender: { id: 77, login: "installer" },
+      repositories: [{ id: 101 }],
+    });
+    const deletedResponse = await handleGithubWebhook(webhookEnv, new Request("https://worker.test/v1/github/webhook", {
+      method: "POST",
+      headers: { "x-hub-signature-256": await webhookSignature(deleted, secret), "x-github-delivery": "delivery-deleted", "x-github-event": "installation" },
+      body: deleted,
+    }));
+    expect(deletedResponse.status).toBe(200);
+    await expect(deletedResponse.json()).resolves.toMatchObject({ data: { status: "accepted" } });
+    expect(fixture.fact()).toMatchObject({ state: "deleted" });
+    expect(fixture.delivery("delivery-deleted")).toMatchObject({ result: "processed" });
   });
 
   it.each(["callback-first", "webhook-first"])("binds the exact installation when %s", async (order) => {

--- a/cloudflare/worker/src/routes/github.ts
+++ b/cloudflare/worker/src/routes/github.ts
@@ -779,7 +779,18 @@ export async function handleGithubCallback(env: Env, _request: Request, url: URL
           await execute(db, "UPDATE github_connection_states SET status = 'rejected', updated_at = ? WHERE nonce_hash = ?", now(), nonceHash);
           throw error;
         }
-      } else throw new GithubControlPlaneError("github_state_consumed", "GitHub connection state was already consumed.", 409);
+      } else {
+        const isPostInstallationReturn = Boolean(
+          installationId &&
+          connectionState.consumed_at &&
+          connectionState.oauth_user_id &&
+          connectionState.oauth_login &&
+          connectionState.status === "oauth_verified",
+        );
+        if (!isPostInstallationReturn) {
+          throw new GithubControlPlaneError("github_state_consumed", "GitHub connection state was already consumed.", 409);
+        }
+      }
     } else if (!installationId) {
       throw new GithubControlPlaneError("github_callback_invalid", "OAuth code or installation hint is required.", 400);
     }
@@ -947,37 +958,42 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
         repositorySelection, factState, deliveryId, observedAt, observedAt, installationId,
       );
     }
-    const repositoryFactState = await queryFirst<{ state: string }>(db, "SELECT state FROM github_installation_facts WHERE installation_id = ? LIMIT 1", installationId);
-    const repositoryState = repositoryFactState?.state === "active" ? "active" : "removed";
-    const addedValues = eventName === "installation_repositories" ? payload.repositories_added : payload.repositories;
-    for (const value of Array.isArray(addedValues) ? addedValues : []) {
-      const repo = webhookRepository(value);
-      if (!repo) throw new GithubControlPlaneError("github_webhook_repository_invalid", "Signed webhook contains an invalid repository fact.", 400);
-      await execute(
-        db,
-        `INSERT INTO github_installation_repositories
-         (installation_id, repository_id, owner_login, name, full_name, is_private, default_branch, state, observed_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-         ON CONFLICT(installation_id, repository_id) DO UPDATE SET
-           owner_login = excluded.owner_login, name = excluded.name, full_name = excluded.full_name,
-           is_private = excluded.is_private, default_branch = excluded.default_branch, state = excluded.state,
-           observed_at = excluded.observed_at, updated_at = excluded.updated_at`,
-        installationId,
-        repo.id,
-        repo.owner.login,
-        repo.name,
-        repo.full_name,
-        repo.private ? 1 : 0,
-        repo.default_branch ?? null,
-        repositoryState,
-        observedAt,
-        observedAt,
-      );
-    }
-    for (const value of Array.isArray(payload.repositories_removed) ? payload.repositories_removed : []) {
-      const repo = webhookRepository(value);
-      if (!repo) throw new GithubControlPlaneError("github_webhook_repository_invalid", "Signed webhook contains an invalid removed repository fact.", 400);
-      await execute(db, "UPDATE github_installation_repositories SET state = 'removed', updated_at = ? WHERE installation_id = ? AND repository_id = ?", observedAt, installationId, repo.id);
+    const installationDeleted = eventName === "installation" && action === "deleted";
+    if (installationDeleted) {
+      await execute(db, "UPDATE github_installation_repositories SET state = 'removed', updated_at = ? WHERE installation_id = ?", observedAt, installationId);
+    } else {
+      const repositoryFactState = await queryFirst<{ state: string }>(db, "SELECT state FROM github_installation_facts WHERE installation_id = ? LIMIT 1", installationId);
+      const repositoryState = repositoryFactState?.state === "active" ? "active" : "removed";
+      const addedValues = eventName === "installation_repositories" ? payload.repositories_added : payload.repositories;
+      for (const value of Array.isArray(addedValues) ? addedValues : []) {
+        const repo = webhookRepository(value);
+        if (!repo) throw new GithubControlPlaneError("github_webhook_repository_invalid", "Signed webhook contains an invalid repository fact.", 400);
+        await execute(
+          db,
+          `INSERT INTO github_installation_repositories
+           (installation_id, repository_id, owner_login, name, full_name, is_private, default_branch, state, observed_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(installation_id, repository_id) DO UPDATE SET
+             owner_login = excluded.owner_login, name = excluded.name, full_name = excluded.full_name,
+             is_private = excluded.is_private, default_branch = excluded.default_branch, state = excluded.state,
+             observed_at = excluded.observed_at, updated_at = excluded.updated_at`,
+          installationId,
+          repo.id,
+          repo.owner.login,
+          repo.name,
+          repo.full_name,
+          repo.private ? 1 : 0,
+          repo.default_branch ?? null,
+          repositoryState,
+          observedAt,
+          observedAt,
+        );
+      }
+      for (const value of Array.isArray(payload.repositories_removed) ? payload.repositories_removed : []) {
+        const repo = webhookRepository(value);
+        if (!repo) throw new GithubControlPlaneError("github_webhook_repository_invalid", "Signed webhook contains an invalid removed repository fact.", 400);
+        await execute(db, "UPDATE github_installation_repositories SET state = 'removed', updated_at = ? WHERE installation_id = ? AND repository_id = ?", observedAt, installationId, repo.id);
+      }
     }
     const storedFact = await queryFirst<{ installer_sender_id: number; state: string }>(db, "SELECT installer_sender_id, state FROM github_installation_facts WHERE installation_id = ? LIMIT 1", installationId);
     if (!storedFact) throw new GithubControlPlaneError("github_installation_untrusted", "Installation trust anchor is missing.", 409, true);


### PR DESCRIPTION
## Summary

- accept GitHub post-install callbacks that repeat the OAuth code only when the signed state was already OAuth-verified and an installation ID is present
- keep bound-state and code-only replays rejected
- process installation deletion without trusting sparse repository objects
- mark all cached repositories removed when an installation is deleted

## Production evidence

A live Sheshiyer installation returned an OAuth code with an installation ID after OAuth, and a later deletion event included sparse repository objects. Both paths failed closed, exposing exact compatibility gaps without creating a workspace binding.

## Verification

- 131 Worker tests pass
- TypeScript check passes
- git diff --check passes
- independent read-only security review found no blocker or P2 issue