### PR TITLE
fix(github): accept compact installation repositories

### DIFF
--- a/cloudflare/worker/src/routes/__tests__/github.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/github.test.ts
@@ -346,6 +346,10 @@ function connectionFlowDb(nonceHash: string) {
             const delivery = deliveries.get(String(args[1]));
             if (delivery) delivery.result = "processed";
           }
+          if (sql.includes("result = 'failed'")) {
+            const delivery = deliveries.get(String(args[0]));
+            if (delivery) delivery.result = "failed";
+          }
           return { success: true, meta: { changes: 1 } };
         },
       };
@@ -988,6 +992,50 @@ describe("GitHub App routes", () => {
     await expect(deletedResponse.json()).resolves.toMatchObject({ data: { status: "accepted" } });
     expect(fixture.fact()).toMatchObject({ state: "deleted" });
     expect(fixture.delivery("delivery-deleted")).toMatchObject({ result: "processed" });
+  });
+
+  it("accepts GitHub's compact repository facts on installation creation", async () => {
+    const nonceHash = await sha256Hex("nonce-compact-created");
+    const fixture = connectionFlowDb(nonceHash);
+    const secret = "webhook-test-secret";
+    const webhookEnv = { ...env(fixture.db), TF_GITHUB_APP_WEBHOOK_SECRET: secret };
+    const created = JSON.stringify({
+      action: "created",
+      installation: { id: 42, account: { id: 7611727, login: "Sheshiyer", type: "User" }, repository_selection: "selected" },
+      sender: { id: 7611727, login: "Sheshiyer" },
+      repositories: [{ id: 1211794578, name: "parkarea-aleph", full_name: "Sheshiyer/parkarea-aleph", private: true }],
+    });
+    const response = await handleGithubWebhook(webhookEnv, new Request("https://worker.test/v1/github/webhook", {
+      method: "POST",
+      headers: { "x-hub-signature-256": await webhookSignature(created, secret), "x-github-delivery": "delivery-compact-created", "x-github-event": "installation" },
+      body: created,
+    }));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ data: { status: "accepted" } });
+    expect(fixture.fact()).toMatchObject({ installation_id: 42, account_id: 7611727, repository_selection: "selected", state: "active" });
+    expect(fixture.delivery("delivery-compact-created")).toMatchObject({ result: "processed" });
+  });
+
+  it("rejects compact repository facts outside the signed installation account", async () => {
+    const nonceHash = await sha256Hex("nonce-cross-account-created");
+    const fixture = connectionFlowDb(nonceHash);
+    const secret = "webhook-test-secret";
+    const webhookEnv = { ...env(fixture.db), TF_GITHUB_APP_WEBHOOK_SECRET: secret };
+    const created = JSON.stringify({
+      action: "created",
+      installation: { id: 42, account: { id: 7611727, login: "Sheshiyer", type: "User" }, repository_selection: "selected" },
+      sender: { id: 7611727, login: "Sheshiyer" },
+      repositories: [{ id: 101, name: "private-repo", full_name: "outsider/private-repo", private: true }],
+    });
+    const response = await handleGithubWebhook(webhookEnv, new Request("https://worker.test/v1/github/webhook", {
+      method: "POST",
+      headers: { "x-hub-signature-256": await webhookSignature(created, secret), "x-github-delivery": "delivery-cross-account-created", "x-github-event": "installation" },
+      body: created,
+    }));
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "github_webhook_repository_invalid" } });
+    expect(fixture.binding()).toBeNull();
+    expect(fixture.delivery("delivery-cross-account-created")).toMatchObject({ result: "failed" });
   });
 
   it.each(["callback-first", "webhook-first"])("binds the exact installation when %s", async (order) => {

--- a/cloudflare/worker/src/routes/github.ts
+++ b/cloudflare/worker/src/routes/github.ts
@@ -85,6 +85,15 @@ interface RepositoryAuthorityRow {
   state: "active" | "removed";
 }
 
+interface WebhookRepositoryFact {
+  id: number;
+  name: string;
+  full_name: string;
+  private: boolean;
+  default_branch: string | null;
+  owner: { id: number; login: string };
+}
+
 interface VerificationRow extends RepositoryAuthorityRow {
   project_id: string;
   workspace_id: string;
@@ -809,11 +818,36 @@ export async function handleGithubCallback(env: Env, _request: Request, url: URL
   }
 }
 
-function webhookRepository(value: unknown): GithubRepository | null {
-  const repo = value as Partial<GithubRepository>;
-  if (!repo || !Number.isSafeInteger(repo.id) || (repo.id ?? 0) <= 0 || !repo.name || !repo.full_name ||
-    !repo.owner?.login || !Number.isSafeInteger(repo.owner.id) || repo.owner.id <= 0) return null;
-  return repo as GithubRepository;
+function webhookRepository(value: unknown, account: GithubInstallationAccountTarget): WebhookRepositoryFact | null {
+  if (!value || typeof value !== "object") return null;
+  const repo = value as Record<string, unknown>;
+  const id = repo.id;
+  const name = repo.name;
+  const fullName = repo.full_name;
+  const isPrivate = repo.private;
+  const defaultBranch = repo.default_branch;
+  if (!Number.isSafeInteger(id) || Number(id) <= 0 || typeof name !== "string" || !name || name.includes("/") ||
+    typeof fullName !== "string" || typeof isPrivate !== "boolean" ||
+    (defaultBranch !== undefined && defaultBranch !== null && (typeof defaultBranch !== "string" || !defaultBranch))) return null;
+  const slash = fullName.indexOf("/");
+  if (slash <= 0 || slash !== fullName.lastIndexOf("/")) return null;
+  const fullNameOwner = fullName.slice(0, slash);
+  const fullNameRepo = fullName.slice(slash + 1);
+  if (fullNameOwner.toLowerCase() !== account.login.toLowerCase() || fullNameRepo.toLowerCase() !== name.toLowerCase()) return null;
+  if (repo.owner !== undefined) {
+    if (!repo.owner || typeof repo.owner !== "object") return null;
+    const owner = repo.owner as Record<string, unknown>;
+    if (!Number.isSafeInteger(owner.id) || Number(owner.id) !== account.id || typeof owner.login !== "string" ||
+      owner.login.toLowerCase() !== account.login.toLowerCase()) return null;
+  }
+  return {
+    id: Number(id),
+    name,
+    full_name: fullName,
+    private: isPrivate,
+    default_branch: typeof defaultBranch === "string" ? defaultBranch : null,
+    owner: { id: account.id, login: account.login },
+  };
 }
 
 export function nextInstallationState(
@@ -966,7 +1000,7 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
       const repositoryState = repositoryFactState?.state === "active" ? "active" : "removed";
       const addedValues = eventName === "installation_repositories" ? payload.repositories_added : payload.repositories;
       for (const value of Array.isArray(addedValues) ? addedValues : []) {
-        const repo = webhookRepository(value);
+        const repo = webhookRepository(value, accountTarget);
         if (!repo) throw new GithubControlPlaneError("github_webhook_repository_invalid", "Signed webhook contains an invalid repository fact.", 400);
         await execute(
           db,
@@ -990,7 +1024,7 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
         );
       }
       for (const value of Array.isArray(payload.repositories_removed) ? payload.repositories_removed : []) {
-        const repo = webhookRepository(value);
+        const repo = webhookRepository(value, accountTarget);
         if (!repo) throw new GithubControlPlaneError("github_webhook_repository_invalid", "Signed webhook contains an invalid removed repository fact.", 400);
         await execute(db, "UPDATE github_installation_repositories SET state = 'removed', updated_at = ? WHERE installation_id = ? AND repository_id = ?", observedAt, installationId, repo.id);
       }


### PR DESCRIPTION
## Summary
- accept GitHub installation-created compact repository objects that omit nested owner and default branch
- derive owner only from the signed installation account after validating the full-name prefix
- reject repository facts whose full name does not belong to that exact installation account

## Production evidence
The selected-only Sheshiyer installation webhook carried repository ID 1211794578 and full name Sheshiyer/parkarea-aleph, but omitted owner and default branch. Production correctly withheld the workspace binding after the parser returned github_webhook_repository_invalid.

## Verification
- pnpm test: 13 files, 133 tests passed
- pnpm check: passed
- git diff --check: passed