### PR TITLE
feat(worker): add scoped weekly reporting context

### DIFF
--- a/ARCHITECTURE_CHANGES_2026-06-09.md
+++ b/ARCHITECTURE_CHANGES_2026-06-09.md
@@ -37,14 +37,19 @@ The TeamForge API Worker is now behind Cloudflare Zero Trust Access.
 
 ### Service Token for API Calls
 ```bash
-CF_ACCESS_CLIENT_ID="5c2a491d82489737b0a98f35461140ca.access"
-CF_ACCESS_CLIENT_SECRET="f42c67ea72db8ee39ee5480a7e7c96e3a18f6eb26ab02730d85e61be2ab46604"
+CF_ACCESS_CLIENT_ID="<service-token-client-id>.access"
+CF_ACCESS_CLIENT_SECRET="<service-token-client-secret>"
 
 curl -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
      -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
      -H "Authorization: Bearer $TF_CREDENTIAL_ENVELOPE_KEY" \
      https://forge.thoughtseed.space/v1/projects
 ```
+
+Never commit Cloudflare Access client IDs or secrets. Inject them from the
+runtime secret store. Treat every value previously committed to Git as exposed:
+rotate it, update consumers, prove the replacement works, then revoke the old
+credential. Redacting this file does not remove values from repository history.
 
 ### Temporary Internal Shared-Secret Bridge (m2m)
 For machine-to-machine calls from IP-bypass-allowed machines when CF Access service tokens fail:

--- a/README.md
+++ b/README.md
@@ -99,14 +99,18 @@ The operating model is now explicitly four planes:
 Example authenticated call (both CF Access headers + app Bearer are required):
 
 ```bash
-CF_ACCESS_CLIENT_ID="21ad48de5aefe985ef5bddbe42a07b8e.access"
-CF_ACCESS_CLIENT_SECRET="e90d3c459f1e8565a44e5ac42ec03704500ae0faf842b3765e31c3e8759095ed"
+CF_ACCESS_CLIENT_ID="<service-token-client-id>.access"
+CF_ACCESS_CLIENT_SECRET="<service-token-client-secret>"
 
 curl -H "CF-Access-Client-Id: $CF_ACCESS_CLIENT_ID" \
      -H "CF-Access-Client-Secret: $CF_ACCESS_CLIENT_SECRET" \
      -H "Authorization: Bearer $TF_CREDENTIAL_ENVELOPE_KEY" \
      https://forge.thoughtseed.space/v1/projects
 ```
+
+Never commit Cloudflare Access client IDs or secrets. Enter them through the
+runtime secret store. Any credential that has ever appeared in Git history must
+be rotated and revoked even after the current documentation is redacted.
 
 **Temporary internal shared-secret bridge (for m2m when service tokens have Worker compatibility issues):**
 

--- a/cloudflare/worker/README.md
+++ b/cloudflare/worker/README.md
@@ -27,6 +27,22 @@ a verified identity) — it is how Plexus resolves the signed-in employee's emai
 `TF_ACCESS_AUDIENCE` is unrelated to JWT verification: it is the
 `/v1/credentials` `?audience=` echo check for the desktop credential handout.
 
+### Weekly reporting context
+
+`GET /v1/reporting/weekly-context` is a separate, read-only machine boundary.
+It accepts only `Authorization: Bearer $TF_REPORTING_READ_TOKEN`; app, webhook,
+credential-envelope, and temporary internal-bridge secrets are not accepted.
+Configure `TF_REPORTING_WORKSPACE_ID` as a server-side Worker variable. Caller
+workspace query parameters are rejected, and the response contains only
+versioned aggregate counts and seven-day/latest-historical freshness metadata.
+Every response sets `Cache-Control: no-store`.
+
+Configure the bearer without printing or committing it:
+
+```bash
+pnpm exec wrangler secret put TF_REPORTING_READ_TOKEN
+```
+
 ## Scope
 
 Wave 1 provides:

--- a/cloudflare/worker/README.md
+++ b/cloudflare/worker/README.md
@@ -30,17 +30,38 @@ a verified identity) — it is how Plexus resolves the signed-in employee's emai
 ### Weekly reporting context
 
 `GET /v1/reporting/weekly-context` is a separate, read-only machine boundary.
-It accepts only `Authorization: Bearer $TF_REPORTING_READ_TOKEN`; app, webhook,
-credential-envelope, and temporary internal-bridge secrets are not accepted.
-Configure `TF_REPORTING_WORKSPACE_ID` as a server-side Worker variable. Caller
-workspace query parameters are rejected, and the response contains only
-versioned aggregate counts and seven-day/latest-historical freshness metadata.
+The custom domain has two independent authentication layers:
+
+1. Cloudflare Access authenticates the machine at the edge using
+   `CF-Access-Client-Id` and `CF-Access-Client-Secret`.
+2. The Worker application authenticates the reporting consumer using
+   `Authorization: Bearer $TF_REPORTING_READ_TOKEN`.
+
+The reporting bearer is dedicated: app credential-envelope, webhook, and
+temporary internal-bridge secrets are not accepted. Configure
+`TF_REPORTING_WORKSPACE_ID` on the Worker; callers cannot select or override a
+workspace. The response contains only versioned aggregate counts and bounded
+seven-day/latest-historical freshness metadata. Overall freshness is `fresh`
+only when all four required sources are fresh; partial evidence is `mixed`.
 Every response sets `Cache-Control: no-store`.
 
-Configure the bearer without printing or committing it:
+Configure both server-owned values without printing or committing them:
 
 ```bash
 pnpm exec wrangler secret put TF_REPORTING_READ_TOKEN
+pnpm exec wrangler secret put TF_REPORTING_WORKSPACE_ID
+```
+
+Load the three caller credentials from an approved runtime secret store, then
+run a redacted metadata-only probe. Never inline their values in shell history:
+
+```bash
+curl --fail-with-body --silent --show-error \
+  -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID:?load from secret store}" \
+  -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET:?load from secret store}" \
+  -H "Authorization: Bearer ${TF_REPORTING_READ_TOKEN:?load from secret store}" \
+  "${TEAMFORGE_BASE_URL:?set base URL}/v1/reporting/weekly-context" \
+  | jq '{ok,schemaVersion:.data.schemaVersion,generatedAt:.data.generatedAt,window:.data.window,projects:.data.projects,clients:.data.clients,kpis:.data.kpis,freshness:.data.freshness}'
 ```
 
 ## Scope

--- a/cloudflare/worker/src/lib/auth.ts
+++ b/cloudflare/worker/src/lib/auth.ts
@@ -14,7 +14,7 @@ function readBearerToken(request: Request): string | null {
 export function requireBearerAuth(
   request: Request,
   expectedToken: string | undefined,
-  context: "app" | "credentials" | "internal",
+  context: "app" | "credentials" | "internal" | "reporting",
 ): Response | null {
   if (!expectedToken) {
     return jsonError(

--- a/cloudflare/worker/src/lib/auth.ts
+++ b/cloudflare/worker/src/lib/auth.ts
@@ -14,7 +14,7 @@ function readBearerToken(request: Request): string | null {
 export function requireBearerAuth(
   request: Request,
   expectedToken: string | undefined,
-  context: "app" | "credentials" | "internal" | "reporting",
+  context: "app" | "credentials" | "internal",
 ): Response | null {
   if (!expectedToken) {
     return jsonError(

--- a/cloudflare/worker/src/lib/env.ts
+++ b/cloudflare/worker/src/lib/env.ts
@@ -72,6 +72,12 @@ export interface Env {
   TF_CREDENTIAL_ENVELOPE_KEY?: string;
   TF_WEBHOOK_HMAC_SECRET?: string;
   TF_RELEASE_PUBLISH_TOKEN?: string;
+  // Dedicated, read-only weekly reporting boundary. This bearer is not shared
+  // with app, credential handout, webhook, or temporary bridge routes.
+  TF_REPORTING_READ_TOKEN?: string;
+  // Server-owned scope for the weekly reporting route. Callers cannot select
+  // or override a workspace.
+  TF_REPORTING_WORKSPACE_ID?: string;
   TEAMFORGE_DB?: D1DatabaseLike;
   TEAMFORGE_ARTIFACTS?: R2BucketLike;
   SYNC_QUEUE?: QueueLike<SyncJobMessage>;

--- a/cloudflare/worker/src/lib/reporting-auth.test.ts
+++ b/cloudflare/worker/src/lib/reporting-auth.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { requireReportingBearerAuth } from "./reporting-auth";
+
+function request(token?: string): Request {
+  return new Request("https://forge.example/v1/reporting/weekly-context", {
+    headers: token === undefined ? undefined : { authorization: `Bearer ${token}` },
+  });
+}
+
+describe("reporting bearer verifier", () => {
+  it("returns 503 when the dedicated secret is not configured", async () => {
+    const response = await requireReportingBearerAuth(request("presented"), undefined);
+
+    expect(response?.status).toBe(503);
+    expect((await response?.json()).error.code).toBe("server_misconfigured");
+  });
+
+  it("returns 401 when no bearer is presented", async () => {
+    const response = await requireReportingBearerAuth(request(), "expected-secret");
+
+    expect(response?.status).toBe(401);
+    expect((await response?.json()).error.code).toBe("missing_authorization");
+  });
+
+  it("accepts an exact dedicated bearer", async () => {
+    await expect(requireReportingBearerAuth(request("expected-secret"), "expected-secret"))
+      .resolves.toBeNull();
+  });
+
+  it.each([
+    ["expected-secreu", "same-length mismatch"],
+    ["short", "shorter mismatch"],
+    ["expected-secret-with-extra-bytes", "longer mismatch"],
+  ])("rejects %s using digest comparison (%s)", async (presented) => {
+    const response = await requireReportingBearerAuth(request(presented), "expected-secret");
+
+    expect(response?.status).toBe(403);
+    expect((await response?.json()).error.code).toBe("invalid_authorization");
+  });
+});

--- a/cloudflare/worker/src/lib/reporting-auth.ts
+++ b/cloudflare/worker/src/lib/reporting-auth.ts
@@ -1,0 +1,78 @@
+import { jsonError } from "./response";
+
+function readBearerToken(request: Request): string | null {
+  const header = request.headers.get("authorization");
+  if (!header) return null;
+
+  const match = header.match(/^Bearer[\t ]+([^\s]+)[\t ]*$/i);
+  return match?.[1] ?? null;
+}
+
+async function sha256(value: string): Promise<Uint8Array> {
+  const input = new TextEncoder().encode(value);
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", input));
+}
+
+function constantTimeEqual(left: Uint8Array, right: Uint8Array): boolean {
+  const comparedLength = Math.max(left.length, right.length);
+  let mismatch = left.length ^ right.length;
+
+  for (let index = 0; index < comparedLength; index += 1) {
+    mismatch |= (left[index] ?? 0) ^ (right[index] ?? 0);
+  }
+
+  return mismatch === 0;
+}
+
+/**
+ * Dedicated verifier for the reporting machine boundary.
+ *
+ * Hashing both inputs before a fixed-length byte comparison prevents the
+ * reporting route from inheriting the early-exit string comparison used by
+ * legacy app routes. Missing configuration and missing credentials still fail
+ * before hashing because neither case compares attacker-controlled secrets.
+ */
+export async function requireReportingBearerAuth(
+  request: Request,
+  expectedToken: string | undefined,
+): Promise<Response | null> {
+  if (!expectedToken) {
+    return jsonError(
+      {
+        code: "server_misconfigured",
+        message: "Missing secret for reporting route protection.",
+        retryable: false,
+      },
+      503,
+    );
+  }
+
+  const providedToken = readBearerToken(request);
+  if (!providedToken) {
+    return jsonError(
+      {
+        code: "missing_authorization",
+        message: "Authorization header with Bearer token is required.",
+        retryable: false,
+      },
+      401,
+    );
+  }
+
+  const [providedDigest, expectedDigest] = await Promise.all([
+    sha256(providedToken),
+    sha256(expectedToken),
+  ]);
+  if (!constantTimeEqual(providedDigest, expectedDigest)) {
+    return jsonError(
+      {
+        code: "invalid_authorization",
+        message: "Invalid bearer token.",
+        retryable: false,
+      },
+      403,
+    );
+  }
+
+  return null;
+}

--- a/cloudflare/worker/src/routes/reporting.test.ts
+++ b/cloudflare/worker/src/routes/reporting.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import type { D1DatabaseLike, Env } from "../lib/env";
+import { handleGetWeeklyReportingContext } from "./reporting";
+
+interface ReportingRows {
+  projects?: Record<string, unknown>;
+  client_profiles?: Record<string, unknown>;
+  employees?: Record<string, unknown>;
+  time_entries?: Record<string, unknown>;
+}
+
+interface BoundQuery {
+  sql: string;
+  values: unknown[];
+}
+
+function makeReportingDb(rows: ReportingRows, error?: Error): {
+  db: D1DatabaseLike;
+  queries: BoundQuery[];
+} {
+  const queries: BoundQuery[] = [];
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(...values: unknown[]) {
+          queries.push({ sql, values });
+          return {
+            bind() {
+              return this;
+            },
+            async first<T>() {
+              if (error) throw error;
+              const table = (Object.keys(rows) as Array<keyof ReportingRows>)
+                .find((candidate) => sql.includes(`FROM ${candidate}`));
+              return (table ? rows[table] : null) as T | null;
+            },
+            async run() {
+              return { success: true };
+            },
+            async all<T>() {
+              return { results: [] as T[] };
+            },
+          };
+        },
+        async first<T>() {
+          if (error) throw error;
+          return null as T | null;
+        },
+        async run() {
+          return { success: true };
+        },
+        async all<T>() {
+          return { results: [] as T[] };
+        },
+      };
+    },
+  } as unknown as D1DatabaseLike;
+
+  return { db, queries };
+}
+
+function request(query = "", token = "reporting-secret"): Request {
+  return new Request(`https://forge.example/v1/reporting/weekly-context${query}`, {
+    headers: token ? { authorization: `Bearer ${token}` } : undefined,
+  });
+}
+
+function env(db: D1DatabaseLike, overrides: Partial<Env> = {}): Env {
+  return {
+    TF_ENV: "test",
+    TF_REPORTING_READ_TOKEN: "reporting-secret",
+    TF_REPORTING_WORKSPACE_ID: "configured-workspace",
+    TEAMFORGE_DB: db,
+    ...overrides,
+  };
+}
+
+async function body(response: Response): Promise<Record<string, any>> {
+  return response.json() as Promise<Record<string, any>>;
+}
+
+describe("GET /v1/reporting/weekly-context", () => {
+  it("returns 401 for a missing dedicated bearer", async () => {
+    const mock = makeReportingDb({});
+    const req = request("", "");
+    const response = await handleGetWeeklyReportingContext(req, env(mock.db), new URL(req.url));
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect((await body(response)).error.code).toBe("missing_authorization");
+    expect(mock.queries).toHaveLength(0);
+  });
+
+  it("returns 403 for the wrong dedicated bearer", async () => {
+    const mock = makeReportingDb({});
+    const req = request("", "wrong-secret");
+    const response = await handleGetWeeklyReportingContext(req, env(mock.db), new URL(req.url));
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect((await body(response)).error.code).toBe("invalid_authorization");
+    expect(mock.queries).toHaveLength(0);
+  });
+
+  it("returns 503 when the server reporting workspace is missing", async () => {
+    const mock = makeReportingDb({});
+    const req = request();
+    const response = await handleGetWeeklyReportingContext(
+      req,
+      env(mock.db, { TF_REPORTING_WORKSPACE_ID: "" }),
+      new URL(req.url),
+    );
+
+    expect(response.status).toBe(503);
+    expect((await body(response)).error.code).toBe("reporting_workspace_not_configured");
+    expect(mock.queries).toHaveLength(0);
+  });
+
+  it.each(["?workspace_id=attacker", "?workspaceId=attacker"])(
+    "rejects caller workspace override %s before querying",
+    async (query) => {
+      const mock = makeReportingDb({});
+      const req = request(query);
+      const response = await handleGetWeeklyReportingContext(req, env(mock.db), new URL(req.url));
+
+      expect(response.status).toBe(400);
+      expect((await body(response)).error.code).toBe("workspace_override_forbidden");
+      expect(mock.queries).toHaveLength(0);
+    },
+  );
+
+  it("returns the bounded v1 schema and scopes every query to the configured workspace", async () => {
+    const mock = makeReportingDb({
+      projects: {
+        total: 23,
+        active: 17,
+        completed: 3,
+        archived: 1,
+        latest_at: "2026-07-14T12:00:00.000Z",
+        recent_count: 4,
+      },
+      client_profiles: {
+        total: 9,
+        active: 9,
+        latest_at: "2026-07-02T12:00:00.000Z",
+        recent_count: 0,
+      },
+      employees: {
+        total: 7,
+        active: 6,
+        latest_at: "2026-07-13T12:00:00.000Z",
+        recent_count: 1,
+      },
+      time_entries: {
+        total: 1414,
+        total_duration_seconds: 720000,
+        latest_at: "2026-07-05T12:00:00.000Z",
+        recent_count: 0,
+        recent_duration_seconds: 0,
+      },
+    });
+    const req = request();
+    const response = await handleGetWeeklyReportingContext(
+      req,
+      env(mock.db),
+      new URL(req.url),
+      new Date("2026-07-15T12:00:00.000Z"),
+    );
+    const payload = await body(response);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(payload).toEqual({
+      ok: true,
+      data: {
+        schemaVersion: "teamforge.weekly-context.v1",
+        generatedAt: "2026-07-15T12:00:00.000Z",
+        window: {
+          days: 7,
+          startsAt: "2026-07-08T12:00:00.000Z",
+          endsAt: "2026-07-15T12:00:00.000Z",
+        },
+        projects: {
+          total: 23,
+          active: 17,
+          completed: 3,
+          archived: 1,
+          other: 2,
+          updatedLast7Days: 4,
+        },
+        clients: {
+          total: 9,
+          active: 9,
+          inactive: 0,
+          updatedLast7Days: 0,
+        },
+        kpis: {
+          employees: { total: 7, active: 6 },
+          timeEntries: {
+            totalHistorical: 1414,
+            totalLast7Days: 0,
+            durationSecondsHistorical: 720000,
+            durationSecondsLast7Days: 0,
+          },
+        },
+        freshness: {
+          status: "fresh",
+          latestHistoricalAt: "2026-07-14T12:00:00.000Z",
+          signalsLast7Days: 5,
+          sources: [
+            { source: "projects", status: "fresh", latestHistoricalAt: "2026-07-14T12:00:00.000Z", signalsLast7Days: 4 },
+            { source: "clients", status: "stale", latestHistoricalAt: "2026-07-02T12:00:00.000Z", signalsLast7Days: 0 },
+            { source: "employees", status: "fresh", latestHistoricalAt: "2026-07-13T12:00:00.000Z", signalsLast7Days: 1 },
+            { source: "time_entries", status: "stale", latestHistoricalAt: "2026-07-05T12:00:00.000Z", signalsLast7Days: 0 },
+          ],
+        },
+      },
+    });
+
+    expect(mock.queries).toHaveLength(4);
+    expect(mock.queries.every(({ values }) => values.at(-1) === "configured-workspace")).toBe(true);
+    expect(JSON.stringify(payload)).not.toMatch(/workspace|email|name|external|credential/i);
+  });
+
+  it("labels latest historical data as stale when the seven-day window is empty", async () => {
+    const stale = {
+      total: 1,
+      active: 1,
+      completed: 0,
+      archived: 0,
+      total_duration_seconds: 60,
+      latest_at: "2026-06-01T00:00:00.000Z",
+      recent_count: 0,
+      recent_duration_seconds: 0,
+    };
+    const mock = makeReportingDb({
+      projects: stale,
+      client_profiles: stale,
+      employees: stale,
+      time_entries: stale,
+    });
+    const req = request();
+    const response = await handleGetWeeklyReportingContext(
+      req,
+      env(mock.db),
+      new URL(req.url),
+      new Date("2026-07-15T00:00:00.000Z"),
+    );
+    const payload = await body(response);
+
+    expect(payload.data.freshness.status).toBe("stale");
+    expect(payload.data.freshness.latestHistoricalAt).toBe("2026-06-01T00:00:00.000Z");
+    expect(payload.data.freshness.signalsLast7Days).toBe(0);
+  });
+
+  it("returns a safe 503 when aggregate queries fail", async () => {
+    const mock = makeReportingDb({}, new Error("sensitive database detail"));
+    const req = request();
+    const response = await handleGetWeeklyReportingContext(req, env(mock.db), new URL(req.url));
+    const payload = await body(response);
+
+    expect(response.status).toBe(503);
+    expect(payload.error.code).toBe("reporting_source_unavailable");
+    expect(JSON.stringify(payload)).not.toContain("sensitive database detail");
+  });
+});

--- a/cloudflare/worker/src/routes/reporting.test.ts
+++ b/cloudflare/worker/src/routes/reporting.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { D1DatabaseLike, Env } from "../lib/env";
+import worker from "../index";
 import { handleGetWeeklyReportingContext } from "./reporting";
 
 interface ReportingRows {
@@ -79,6 +80,10 @@ async function body(response: Response): Promise<Record<string, any>> {
   return response.json() as Promise<Record<string, any>>;
 }
 
+function epoch(timestamp: string): number {
+  return Math.trunc(Date.parse(timestamp) / 1_000);
+}
+
 describe("GET /v1/reporting/weekly-context", () => {
   it("returns 401 for a missing dedicated bearer", async () => {
     const mock = makeReportingDb({});
@@ -100,6 +105,32 @@ describe("GET /v1/reporting/weekly-context", () => {
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect((await body(response)).error.code).toBe("invalid_authorization");
     expect(mock.queries).toHaveLength(0);
+  });
+
+  it("routes through the Worker and returns 503 when the dedicated secret is missing", async () => {
+    const mock = makeReportingDb({});
+    const req = request();
+    const response = await worker.fetch(
+      req,
+      env(mock.db, { TF_REPORTING_READ_TOKEN: undefined }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect((await body(response)).error.code).toBe("server_misconfigured");
+    expect(mock.queries).toHaveLength(0);
+  });
+
+  it("routes a valid dedicated bearer to the bounded reporting handler", async () => {
+    const mock = makeReportingDb({});
+    const req = request();
+    const response = await worker.fetch(req, env(mock.db));
+    const payload = await body(response);
+
+    expect(response.status).toBe(200);
+    expect(payload.data.schemaVersion).toBe("teamforge.weekly-context.v1");
+    expect(payload.data.freshness.status).toBe("no_signal");
+    expect(mock.queries).toHaveLength(4);
   });
 
   it("returns 503 when the server reporting workspace is missing", async () => {
@@ -136,25 +167,25 @@ describe("GET /v1/reporting/weekly-context", () => {
         active: 17,
         completed: 3,
         archived: 1,
-        latest_at: "2026-07-14T12:00:00.000Z",
+        latest_epoch: epoch("2026-07-14T12:00:00.000Z"),
         recent_count: 4,
       },
       client_profiles: {
         total: 9,
         active: 9,
-        latest_at: "2026-07-02T12:00:00.000Z",
+        latest_epoch: epoch("2026-07-02T12:00:00.000Z"),
         recent_count: 0,
       },
       employees: {
         total: 7,
         active: 6,
-        latest_at: "2026-07-13T12:00:00.000Z",
+        latest_epoch: epoch("2026-07-13T12:00:00.000Z"),
         recent_count: 1,
       },
       time_entries: {
         total: 1414,
         total_duration_seconds: 720000,
-        latest_at: "2026-07-05T12:00:00.000Z",
+        latest_epoch: epoch("2026-07-05T12:00:00.000Z"),
         recent_count: 0,
         recent_duration_seconds: 0,
       },
@@ -204,7 +235,7 @@ describe("GET /v1/reporting/weekly-context", () => {
           },
         },
         freshness: {
-          status: "fresh",
+          status: "mixed",
           latestHistoricalAt: "2026-07-14T12:00:00.000Z",
           signalsLast7Days: 5,
           sources: [
@@ -219,7 +250,124 @@ describe("GET /v1/reporting/weekly-context", () => {
 
     expect(mock.queries).toHaveLength(4);
     expect(mock.queries.every(({ values }) => values.at(-1) === "configured-workspace")).toBe(true);
+    expect(mock.queries.every(({ sql }) => sql.includes("unixepoch("))).toBe(true);
+    expect(mock.queries.every(({ sql }) => sql.includes("<= unixepoch(?)"))).toBe(true);
+    expect(mock.queries.every(({ values }) => values.includes("2026-07-08T12:00:00.000Z"))).toBe(true);
+    expect(mock.queries.every(({ values }) => values.includes("2026-07-15T12:00:00.000Z"))).toBe(true);
     expect(JSON.stringify(payload)).not.toMatch(/workspace|email|name|external|credential/i);
+  });
+
+  it("reports fresh only when every required source is fresh", async () => {
+    const fresh = {
+      total: 2,
+      active: 2,
+      completed: 0,
+      archived: 0,
+      total_duration_seconds: 600,
+      latest_epoch: epoch("2026-07-14T00:00:00.000Z"),
+      recent_count: 2,
+      recent_duration_seconds: 600,
+    };
+    const mock = makeReportingDb({
+      projects: fresh,
+      client_profiles: fresh,
+      employees: fresh,
+      time_entries: fresh,
+    });
+    const req = request();
+    const response = await handleGetWeeklyReportingContext(
+      req,
+      env(mock.db),
+      new URL(req.url),
+      new Date("2026-07-15T00:00:00.000Z"),
+    );
+    const payload = await body(response);
+
+    expect(payload.data.freshness.status).toBe("fresh");
+    expect(payload.data.freshness.sources.every(({ status }: { status: string }) => status === "fresh")).toBe(true);
+  });
+
+  it("reports mixed when a required source has no signal", async () => {
+    const fresh = {
+      total: 1,
+      active: 1,
+      completed: 0,
+      archived: 0,
+      total_duration_seconds: 60,
+      latest_epoch: epoch("2026-07-14T00:00:00.000Z"),
+      recent_count: 1,
+      recent_duration_seconds: 60,
+    };
+    const mock = makeReportingDb({
+      projects: fresh,
+      client_profiles: { ...fresh, total: 0, active: 0, latest_epoch: null, recent_count: 0 },
+      employees: fresh,
+      time_entries: fresh,
+    });
+    const req = request();
+    const response = await handleGetWeeklyReportingContext(
+      req,
+      env(mock.db),
+      new URL(req.url),
+      new Date("2026-07-15T00:00:00.000Z"),
+    );
+    const payload = await body(response);
+
+    expect(payload.data.freshness.status).toBe("mixed");
+    expect(payload.data.freshness.sources[1]).toEqual({
+      source: "clients",
+      status: "no_signal",
+      latestHistoricalAt: null,
+      signalsLast7Days: 0,
+    });
+  });
+
+  it("normalizes offsets and refuses future or invalid latest timestamps", async () => {
+    const mock = makeReportingDb({
+      projects: {
+        total: 1,
+        active: 1,
+        completed: 0,
+        archived: 0,
+        latest_epoch: epoch("2026-07-15T00:01:00.000Z"),
+        recent_count: 0,
+      },
+      client_profiles: {
+        total: 1,
+        active: 1,
+        latest_epoch: "invalid-epoch",
+        recent_count: 0,
+      },
+      employees: {
+        total: 1,
+        active: 1,
+        latest_epoch: epoch("2026-07-15T05:30:00+05:30"),
+        recent_count: 1,
+      },
+      time_entries: {
+        total: 1,
+        total_duration_seconds: 60,
+        latest_epoch: epoch("2026-06-01T00:00:00.000Z"),
+        recent_count: 0,
+        recent_duration_seconds: 0,
+      },
+    });
+    const req = request();
+    const response = await handleGetWeeklyReportingContext(
+      req,
+      env(mock.db),
+      new URL(req.url),
+      new Date("2026-07-15T00:00:00.000Z"),
+    );
+    const payload = await body(response);
+
+    expect(payload.data.freshness.status).toBe("mixed");
+    expect(payload.data.freshness.sources).toEqual([
+      { source: "projects", status: "no_signal", latestHistoricalAt: null, signalsLast7Days: 0 },
+      { source: "clients", status: "no_signal", latestHistoricalAt: null, signalsLast7Days: 0 },
+      { source: "employees", status: "fresh", latestHistoricalAt: "2026-07-15T00:00:00.000Z", signalsLast7Days: 1 },
+      { source: "time_entries", status: "stale", latestHistoricalAt: "2026-06-01T00:00:00.000Z", signalsLast7Days: 0 },
+    ]);
   });
 
   it("labels latest historical data as stale when the seven-day window is empty", async () => {
@@ -229,7 +377,7 @@ describe("GET /v1/reporting/weekly-context", () => {
       completed: 0,
       archived: 0,
       total_duration_seconds: 60,
-      latest_at: "2026-06-01T00:00:00.000Z",
+      latest_epoch: epoch("2026-06-01T00:00:00.000Z"),
       recent_count: 0,
       recent_duration_seconds: 0,
     };

--- a/cloudflare/worker/src/routes/reporting.ts
+++ b/cloudflare/worker/src/routes/reporting.ts
@@ -1,6 +1,6 @@
 import type { D1DatabaseLike, Env } from "../lib/env";
-import { requireBearerAuth } from "../lib/auth";
 import { queryFirst } from "../lib/db";
+import { requireReportingBearerAuth } from "../lib/reporting-auth";
 import { jsonError, jsonOk } from "../lib/response";
 
 const WINDOW_DAYS = 7;
@@ -11,37 +11,38 @@ interface ProjectAggregateRow {
   active: number | string | null;
   completed: number | string | null;
   archived: number | string | null;
-  latest_at: string | null;
+  latest_epoch: number | string | null;
   recent_count: number | string | null;
 }
 
 interface ClientAggregateRow {
   total: number | string | null;
   active: number | string | null;
-  latest_at: string | null;
+  latest_epoch: number | string | null;
   recent_count: number | string | null;
 }
 
 interface EmployeeAggregateRow {
   total: number | string | null;
   active: number | string | null;
-  latest_at: string | null;
+  latest_epoch: number | string | null;
   recent_count: number | string | null;
 }
 
 interface TimeAggregateRow {
   total: number | string | null;
   total_duration_seconds: number | string | null;
-  latest_at: string | null;
+  latest_epoch: number | string | null;
   recent_count: number | string | null;
   recent_duration_seconds: number | string | null;
 }
 
-type FreshnessStatus = "fresh" | "stale" | "no_signal";
+type SourceFreshnessStatus = "fresh" | "stale" | "no_signal";
+type OverallFreshnessStatus = SourceFreshnessStatus | "mixed";
 
 interface FreshnessSource {
   source: "projects" | "clients" | "employees" | "time_entries";
-  status: FreshnessStatus;
+  status: SourceFreshnessStatus;
   latestHistoricalAt: string | null;
   signalsLast7Days: number;
 }
@@ -56,15 +57,29 @@ function noStore(response: Response): Response {
   return response;
 }
 
+function timestampFromEpoch(value: number | string | null | undefined, generatedAtMs: number): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  const epochSeconds = Number(value);
+  if (!Number.isFinite(epochSeconds)) return null;
+
+  const timestampMs = Math.trunc(epochSeconds) * 1_000;
+  if (!Number.isFinite(timestampMs) || timestampMs > generatedAtMs) return null;
+
+  const timestamp = new Date(timestampMs);
+  return Number.isFinite(timestamp.getTime()) ? timestamp.toISOString() : null;
+}
+
 function sourceFreshness(
   source: FreshnessSource["source"],
-  latestHistoricalAt: string | null,
+  latestEpoch: number | string | null | undefined,
   signalsLast7Days: number,
-  windowStartsAt: string,
+  windowStartsAtMs: number,
+  generatedAtMs: number,
 ): FreshnessSource {
-  const status: FreshnessStatus = latestHistoricalAt === null
+  const latestHistoricalAt = timestampFromEpoch(latestEpoch, generatedAtMs);
+  const status: SourceFreshnessStatus = latestHistoricalAt === null
     ? "no_signal"
-    : latestHistoricalAt >= windowStartsAt
+    : Date.parse(latestHistoricalAt) >= windowStartsAtMs
       ? "fresh"
       : "stale";
 
@@ -74,6 +89,12 @@ function sourceFreshness(
     latestHistoricalAt,
     signalsLast7Days,
   };
+}
+
+function overallFreshness(sources: FreshnessSource[]): OverallFreshnessStatus {
+  const states = new Set(sources.map((source) => source.status));
+  if (states.size !== 1) return "mixed";
+  return sources[0]?.status ?? "no_signal";
 }
 
 function latestTimestamp(sources: FreshnessSource[]): string | null {
@@ -88,6 +109,7 @@ async function queryWeeklyAggregates(
   db: D1DatabaseLike,
   workspaceId: string,
   windowStartsAt: string,
+  generatedAt: string,
 ) {
   const [projects, clients, employees, timeEntries] = await Promise.all([
     queryFirst<ProjectAggregateRow>(
@@ -97,11 +119,18 @@ async function queryWeeklyAggregates(
          COALESCE(SUM(CASE WHEN LOWER(status) = 'active' THEN 1 ELSE 0 END), 0) AS active,
          COALESCE(SUM(CASE WHEN LOWER(status) = 'completed' THEN 1 ELSE 0 END), 0) AS completed,
          COALESCE(SUM(CASE WHEN LOWER(status) = 'archived' THEN 1 ELSE 0 END), 0) AS archived,
-         MAX(updated_at) AS latest_at,
-         COALESCE(SUM(CASE WHEN updated_at >= ? THEN 1 ELSE 0 END), 0) AS recent_count
+         MAX(CASE
+           WHEN unixepoch(updated_at) <= unixepoch(?) THEN unixepoch(updated_at)
+         END) AS latest_epoch,
+         COALESCE(SUM(CASE
+           WHEN unixepoch(updated_at) >= unixepoch(?)
+             AND unixepoch(updated_at) <= unixepoch(?) THEN 1 ELSE 0
+         END), 0) AS recent_count
        FROM projects
        WHERE workspace_id = ?`,
+      generatedAt,
       windowStartsAt,
+      generatedAt,
       workspaceId,
     ),
     queryFirst<ClientAggregateRow>(
@@ -109,11 +138,18 @@ async function queryWeeklyAggregates(
       `SELECT
          COUNT(*) AS total,
          COALESCE(SUM(CASE WHEN active = 1 THEN 1 ELSE 0 END), 0) AS active,
-         MAX(updated_at) AS latest_at,
-         COALESCE(SUM(CASE WHEN updated_at >= ? THEN 1 ELSE 0 END), 0) AS recent_count
+         MAX(CASE
+           WHEN unixepoch(updated_at) <= unixepoch(?) THEN unixepoch(updated_at)
+         END) AS latest_epoch,
+         COALESCE(SUM(CASE
+           WHEN unixepoch(updated_at) >= unixepoch(?)
+             AND unixepoch(updated_at) <= unixepoch(?) THEN 1 ELSE 0
+         END), 0) AS recent_count
        FROM client_profiles
        WHERE workspace_id = ?`,
+      generatedAt,
       windowStartsAt,
+      generatedAt,
       workspaceId,
     ),
     queryFirst<EmployeeAggregateRow>(
@@ -121,11 +157,18 @@ async function queryWeeklyAggregates(
       `SELECT
          COUNT(*) AS total,
          COALESCE(SUM(CASE WHEN is_active = 1 THEN 1 ELSE 0 END), 0) AS active,
-         MAX(updated_at) AS latest_at,
-         COALESCE(SUM(CASE WHEN updated_at >= ? THEN 1 ELSE 0 END), 0) AS recent_count
+         MAX(CASE
+           WHEN unixepoch(updated_at) <= unixepoch(?) THEN unixepoch(updated_at)
+         END) AS latest_epoch,
+         COALESCE(SUM(CASE
+           WHEN unixepoch(updated_at) >= unixepoch(?)
+             AND unixepoch(updated_at) <= unixepoch(?) THEN 1 ELSE 0
+         END), 0) AS recent_count
        FROM employees
        WHERE workspace_id = ?`,
+      generatedAt,
       windowStartsAt,
+      generatedAt,
       workspaceId,
     ),
     queryFirst<TimeAggregateRow>(
@@ -133,13 +176,24 @@ async function queryWeeklyAggregates(
       `SELECT
          COUNT(*) AS total,
          COALESCE(SUM(duration_seconds), 0) AS total_duration_seconds,
-         MAX(COALESCE(end_time, start_time, updated_at, created_at)) AS latest_at,
-         COALESCE(SUM(CASE WHEN start_time >= ? THEN 1 ELSE 0 END), 0) AS recent_count,
-         COALESCE(SUM(CASE WHEN start_time >= ? THEN duration_seconds ELSE 0 END), 0) AS recent_duration_seconds
+         MAX(CASE
+           WHEN unixepoch(start_time) <= unixepoch(?) THEN unixepoch(start_time)
+         END) AS latest_epoch,
+         COALESCE(SUM(CASE
+           WHEN unixepoch(start_time) >= unixepoch(?)
+             AND unixepoch(start_time) <= unixepoch(?) THEN 1 ELSE 0
+         END), 0) AS recent_count,
+         COALESCE(SUM(CASE
+           WHEN unixepoch(start_time) >= unixepoch(?)
+             AND unixepoch(start_time) <= unixepoch(?) THEN duration_seconds ELSE 0
+         END), 0) AS recent_duration_seconds
        FROM time_entries
        WHERE workspace_id = ?`,
+      generatedAt,
       windowStartsAt,
+      generatedAt,
       windowStartsAt,
+      generatedAt,
       workspaceId,
     ),
   ]);
@@ -153,7 +207,7 @@ export async function handleGetWeeklyReportingContext(
   url: URL,
   now = new Date(),
 ): Promise<Response> {
-  const authFailure = requireBearerAuth(request, env.TF_REPORTING_READ_TOKEN, "reporting");
+  const authFailure = await requireReportingBearerAuth(request, env.TF_REPORTING_READ_TOKEN);
   if (authFailure) return noStore(authFailure);
 
   if (url.searchParams.has("workspace_id") || url.searchParams.has("workspaceId")) {
@@ -191,10 +245,12 @@ export async function handleGetWeeklyReportingContext(
   }
 
   const generatedAt = now.toISOString();
-  const windowStartsAt = new Date(now.getTime() - WINDOW_MS).toISOString();
+  const generatedAtMs = now.getTime();
+  const windowStartsAtMs = generatedAtMs - WINDOW_MS;
+  const windowStartsAt = new Date(windowStartsAtMs).toISOString();
 
   try {
-    const aggregates = await queryWeeklyAggregates(env.TEAMFORGE_DB, workspaceId, windowStartsAt);
+    const aggregates = await queryWeeklyAggregates(env.TEAMFORGE_DB, workspaceId, windowStartsAt, generatedAt);
     const projectTotal = count(aggregates.projects?.total);
     const projectActive = count(aggregates.projects?.active);
     const projectCompleted = count(aggregates.projects?.completed);
@@ -203,10 +259,10 @@ export async function handleGetWeeklyReportingContext(
     const clientActive = count(aggregates.clients?.active);
 
     const sources: FreshnessSource[] = [
-      sourceFreshness("projects", aggregates.projects?.latest_at ?? null, count(aggregates.projects?.recent_count), windowStartsAt),
-      sourceFreshness("clients", aggregates.clients?.latest_at ?? null, count(aggregates.clients?.recent_count), windowStartsAt),
-      sourceFreshness("employees", aggregates.employees?.latest_at ?? null, count(aggregates.employees?.recent_count), windowStartsAt),
-      sourceFreshness("time_entries", aggregates.timeEntries?.latest_at ?? null, count(aggregates.timeEntries?.recent_count), windowStartsAt),
+      sourceFreshness("projects", aggregates.projects?.latest_epoch, count(aggregates.projects?.recent_count), windowStartsAtMs, generatedAtMs),
+      sourceFreshness("clients", aggregates.clients?.latest_epoch, count(aggregates.clients?.recent_count), windowStartsAtMs, generatedAtMs),
+      sourceFreshness("employees", aggregates.employees?.latest_epoch, count(aggregates.employees?.recent_count), windowStartsAtMs, generatedAtMs),
+      sourceFreshness("time_entries", aggregates.timeEntries?.latest_epoch, count(aggregates.timeEntries?.recent_count), windowStartsAtMs, generatedAtMs),
     ];
     const latestHistoricalAt = latestTimestamp(sources);
     const signalsLast7Days = sources.reduce((total, source) => total + source.signalsLast7Days, 0);
@@ -246,7 +302,7 @@ export async function handleGetWeeklyReportingContext(
         },
       },
       freshness: {
-        status: latestHistoricalAt === null ? "no_signal" : latestHistoricalAt >= windowStartsAt ? "fresh" : "stale",
+        status: overallFreshness(sources),
         latestHistoricalAt,
         signalsLast7Days,
         sources,

--- a/cloudflare/worker/src/routes/reporting.ts
+++ b/cloudflare/worker/src/routes/reporting.ts
@@ -1,0 +1,265 @@
+import type { D1DatabaseLike, Env } from "../lib/env";
+import { requireBearerAuth } from "../lib/auth";
+import { queryFirst } from "../lib/db";
+import { jsonError, jsonOk } from "../lib/response";
+
+const WINDOW_DAYS = 7;
+const WINDOW_MS = WINDOW_DAYS * 24 * 60 * 60 * 1_000;
+
+interface ProjectAggregateRow {
+  total: number | string | null;
+  active: number | string | null;
+  completed: number | string | null;
+  archived: number | string | null;
+  latest_at: string | null;
+  recent_count: number | string | null;
+}
+
+interface ClientAggregateRow {
+  total: number | string | null;
+  active: number | string | null;
+  latest_at: string | null;
+  recent_count: number | string | null;
+}
+
+interface EmployeeAggregateRow {
+  total: number | string | null;
+  active: number | string | null;
+  latest_at: string | null;
+  recent_count: number | string | null;
+}
+
+interface TimeAggregateRow {
+  total: number | string | null;
+  total_duration_seconds: number | string | null;
+  latest_at: string | null;
+  recent_count: number | string | null;
+  recent_duration_seconds: number | string | null;
+}
+
+type FreshnessStatus = "fresh" | "stale" | "no_signal";
+
+interface FreshnessSource {
+  source: "projects" | "clients" | "employees" | "time_entries";
+  status: FreshnessStatus;
+  latestHistoricalAt: string | null;
+  signalsLast7Days: number;
+}
+
+function count(value: number | string | null | undefined): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? Math.max(0, Math.trunc(parsed)) : 0;
+}
+
+function noStore(response: Response): Response {
+  response.headers.set("cache-control", "no-store");
+  return response;
+}
+
+function sourceFreshness(
+  source: FreshnessSource["source"],
+  latestHistoricalAt: string | null,
+  signalsLast7Days: number,
+  windowStartsAt: string,
+): FreshnessSource {
+  const status: FreshnessStatus = latestHistoricalAt === null
+    ? "no_signal"
+    : latestHistoricalAt >= windowStartsAt
+      ? "fresh"
+      : "stale";
+
+  return {
+    source,
+    status,
+    latestHistoricalAt,
+    signalsLast7Days,
+  };
+}
+
+function latestTimestamp(sources: FreshnessSource[]): string | null {
+  const timestamps = sources
+    .map((source) => source.latestHistoricalAt)
+    .filter((timestamp): timestamp is string => timestamp !== null)
+    .sort();
+  return timestamps.at(-1) ?? null;
+}
+
+async function queryWeeklyAggregates(
+  db: D1DatabaseLike,
+  workspaceId: string,
+  windowStartsAt: string,
+) {
+  const [projects, clients, employees, timeEntries] = await Promise.all([
+    queryFirst<ProjectAggregateRow>(
+      db,
+      `SELECT
+         COUNT(*) AS total,
+         COALESCE(SUM(CASE WHEN LOWER(status) = 'active' THEN 1 ELSE 0 END), 0) AS active,
+         COALESCE(SUM(CASE WHEN LOWER(status) = 'completed' THEN 1 ELSE 0 END), 0) AS completed,
+         COALESCE(SUM(CASE WHEN LOWER(status) = 'archived' THEN 1 ELSE 0 END), 0) AS archived,
+         MAX(updated_at) AS latest_at,
+         COALESCE(SUM(CASE WHEN updated_at >= ? THEN 1 ELSE 0 END), 0) AS recent_count
+       FROM projects
+       WHERE workspace_id = ?`,
+      windowStartsAt,
+      workspaceId,
+    ),
+    queryFirst<ClientAggregateRow>(
+      db,
+      `SELECT
+         COUNT(*) AS total,
+         COALESCE(SUM(CASE WHEN active = 1 THEN 1 ELSE 0 END), 0) AS active,
+         MAX(updated_at) AS latest_at,
+         COALESCE(SUM(CASE WHEN updated_at >= ? THEN 1 ELSE 0 END), 0) AS recent_count
+       FROM client_profiles
+       WHERE workspace_id = ?`,
+      windowStartsAt,
+      workspaceId,
+    ),
+    queryFirst<EmployeeAggregateRow>(
+      db,
+      `SELECT
+         COUNT(*) AS total,
+         COALESCE(SUM(CASE WHEN is_active = 1 THEN 1 ELSE 0 END), 0) AS active,
+         MAX(updated_at) AS latest_at,
+         COALESCE(SUM(CASE WHEN updated_at >= ? THEN 1 ELSE 0 END), 0) AS recent_count
+       FROM employees
+       WHERE workspace_id = ?`,
+      windowStartsAt,
+      workspaceId,
+    ),
+    queryFirst<TimeAggregateRow>(
+      db,
+      `SELECT
+         COUNT(*) AS total,
+         COALESCE(SUM(duration_seconds), 0) AS total_duration_seconds,
+         MAX(COALESCE(end_time, start_time, updated_at, created_at)) AS latest_at,
+         COALESCE(SUM(CASE WHEN start_time >= ? THEN 1 ELSE 0 END), 0) AS recent_count,
+         COALESCE(SUM(CASE WHEN start_time >= ? THEN duration_seconds ELSE 0 END), 0) AS recent_duration_seconds
+       FROM time_entries
+       WHERE workspace_id = ?`,
+      windowStartsAt,
+      windowStartsAt,
+      workspaceId,
+    ),
+  ]);
+
+  return { projects, clients, employees, timeEntries };
+}
+
+export async function handleGetWeeklyReportingContext(
+  request: Request,
+  env: Env,
+  url: URL,
+  now = new Date(),
+): Promise<Response> {
+  const authFailure = requireBearerAuth(request, env.TF_REPORTING_READ_TOKEN, "reporting");
+  if (authFailure) return noStore(authFailure);
+
+  if (url.searchParams.has("workspace_id") || url.searchParams.has("workspaceId")) {
+    return noStore(jsonError(
+      {
+        code: "workspace_override_forbidden",
+        message: "The reporting workspace is configured by the server and cannot be overridden.",
+        retryable: false,
+      },
+      400,
+    ));
+  }
+
+  const workspaceId = env.TF_REPORTING_WORKSPACE_ID?.trim();
+  if (!workspaceId) {
+    return noStore(jsonError(
+      {
+        code: "reporting_workspace_not_configured",
+        message: "The reporting workspace is not configured.",
+        retryable: false,
+      },
+      503,
+    ));
+  }
+
+  if (!env.TEAMFORGE_DB) {
+    return noStore(jsonError(
+      {
+        code: "reporting_source_unavailable",
+        message: "The reporting source is unavailable.",
+        retryable: true,
+      },
+      503,
+    ));
+  }
+
+  const generatedAt = now.toISOString();
+  const windowStartsAt = new Date(now.getTime() - WINDOW_MS).toISOString();
+
+  try {
+    const aggregates = await queryWeeklyAggregates(env.TEAMFORGE_DB, workspaceId, windowStartsAt);
+    const projectTotal = count(aggregates.projects?.total);
+    const projectActive = count(aggregates.projects?.active);
+    const projectCompleted = count(aggregates.projects?.completed);
+    const projectArchived = count(aggregates.projects?.archived);
+    const clientTotal = count(aggregates.clients?.total);
+    const clientActive = count(aggregates.clients?.active);
+
+    const sources: FreshnessSource[] = [
+      sourceFreshness("projects", aggregates.projects?.latest_at ?? null, count(aggregates.projects?.recent_count), windowStartsAt),
+      sourceFreshness("clients", aggregates.clients?.latest_at ?? null, count(aggregates.clients?.recent_count), windowStartsAt),
+      sourceFreshness("employees", aggregates.employees?.latest_at ?? null, count(aggregates.employees?.recent_count), windowStartsAt),
+      sourceFreshness("time_entries", aggregates.timeEntries?.latest_at ?? null, count(aggregates.timeEntries?.recent_count), windowStartsAt),
+    ];
+    const latestHistoricalAt = latestTimestamp(sources);
+    const signalsLast7Days = sources.reduce((total, source) => total + source.signalsLast7Days, 0);
+
+    return noStore(jsonOk({
+      schemaVersion: "teamforge.weekly-context.v1",
+      generatedAt,
+      window: {
+        days: WINDOW_DAYS,
+        startsAt: windowStartsAt,
+        endsAt: generatedAt,
+      },
+      projects: {
+        total: projectTotal,
+        active: projectActive,
+        completed: projectCompleted,
+        archived: projectArchived,
+        other: Math.max(0, projectTotal - projectActive - projectCompleted - projectArchived),
+        updatedLast7Days: count(aggregates.projects?.recent_count),
+      },
+      clients: {
+        total: clientTotal,
+        active: clientActive,
+        inactive: Math.max(0, clientTotal - clientActive),
+        updatedLast7Days: count(aggregates.clients?.recent_count),
+      },
+      kpis: {
+        employees: {
+          total: count(aggregates.employees?.total),
+          active: count(aggregates.employees?.active),
+        },
+        timeEntries: {
+          totalHistorical: count(aggregates.timeEntries?.total),
+          totalLast7Days: count(aggregates.timeEntries?.recent_count),
+          durationSecondsHistorical: count(aggregates.timeEntries?.total_duration_seconds),
+          durationSecondsLast7Days: count(aggregates.timeEntries?.recent_duration_seconds),
+        },
+      },
+      freshness: {
+        status: latestHistoricalAt === null ? "no_signal" : latestHistoricalAt >= windowStartsAt ? "fresh" : "stale",
+        latestHistoricalAt,
+        signalsLast7Days,
+        sources,
+      },
+    }));
+  } catch {
+    return noStore(jsonError(
+      {
+        code: "reporting_source_unavailable",
+        message: "The reporting source could not be summarized.",
+        retryable: true,
+      },
+      503,
+    ));
+  }
+}

--- a/cloudflare/worker/src/routes/v1.ts
+++ b/cloudflare/worker/src/routes/v1.ts
@@ -2,7 +2,7 @@
  * V1 API Router — Safety Audit Note (2026-06-10)
  *
  * Route classification (read-only vs mutation):
- *  READ  — GET  /bootstrap, /remote-config, /projects, /client-profiles, /onboarding-flows,
+ *  READ  — GET  /bootstrap, /remote-config, /reporting/weekly-context, /projects, /client-profiles, /onboarding-flows,
  *               /project-mappings, /project-mappings/issues, /project-mappings/:id/control-plane,
  *               /credentials, /connections, /sync/jobs/:id, /sync/runs, /ota/check,
  *               /team/snapshot, /huly/normalization/history, /handoffs, /handoffs/:id,
@@ -12,7 +12,8 @@
  *               /sync/jobs, /team/refresh, /huly/normalization/preview, /huly/normalization/apply,
  *               /ota/install-events, /handoffs, /handoffs/:id
  *
- * Auth: All app routes require Bearer (TF_CREDENTIAL_ENVELOPE_KEY) or internal secret.
+ * Auth: App routes require Bearer (TF_CREDENTIAL_ENVELOPE_KEY) or internal secret.
+ * /reporting/weekly-context accepts only the dedicated TF_REPORTING_READ_TOKEN.
  * GET /whoami is Access-JWT-only and fail-closed (401 without a verified identity) since WS5.
  * Internal routes (/agent-feed/*, /projects/scaffold, /closeout) use TF_WEBHOOK_HMAC_SECRET.
  * No destructive operations without authentication. No unscoped DELETE endpoints.
@@ -89,6 +90,7 @@ import {
   handleGithubRepoVerify,
   handleGithubWebhook,
 } from "./github";
+import { handleGetWeeklyReportingContext } from "./reporting";
 
 interface DatabaseStatus {
   available: boolean;
@@ -97,6 +99,13 @@ interface DatabaseStatus {
 
 export async function handleV1Request(request: Request, env: Env, url: URL): Promise<Response> {
   const { method, pathname } = { method: request.method, pathname: url.pathname };
+
+  // Dedicated machine-to-machine reporting boundary. Match before Access
+  // identity resolution so this route accepts only TF_REPORTING_READ_TOKEN and
+  // never falls through to the app/internal shared credential tiers.
+  if (method === "GET" && pathname === "/v1/reporting/weekly-context") {
+    return handleGetWeeklyReportingContext(request, env, url);
+  }
 
   // Exact third-party inbound paths. Cloudflare Access must bypass only these
   // two routes; callback state and webhook HMAC independently fail closed.

--- a/cloudflare/worker/wrangler.jsonc
+++ b/cloudflare/worker/wrangler.jsonc
@@ -24,6 +24,9 @@
     "TF_GITHUB_APP_CALLBACK_URL": "https://plexus-api.thoughtseed.space/v1/github/callback",
     "TF_GITHUB_ALLOWED_INSTALLATION_ACCOUNTS": "Organization:thoughtseed-labs:65741640,User:Sheshiyer:7611727,User:psychon7:47470954",
     "TF_GITHUB_ALLOWED_ACTORS": "Sheshiyer:7611727,psychon7:47470954",
+    // Server-owned scope for GET /v1/reporting/weekly-context. The dedicated
+    // TF_REPORTING_READ_TOKEN must be configured with `wrangler secret put`.
+    // "TF_REPORTING_WORKSPACE_ID": "replace-with-workspace-id",
     "TF_INTEGRATION_CONFIG_JSON": "{\"github\":{\"repos\":[{\"repo\":\"Sheshiyer/parkarea-aleph\",\"displayName\":\"ParkArea Phase 2 - Germany Launch\",\"clientName\":\"ParkArea\",\"defaultMilestoneNumber\":1,\"enabled\":true}]},\"huly\":{\"mirrorMode\":\"read_only\",\"mirrorEnabled\":true},\"slack\":{},\"clockify\":{}}",
     // Temporary internal shared secret for m2m (parity, Hermes) bypassing CF Access service token issues on this Worker route.
     // Set a long random value. Callers send header X-TeamForge-Internal-Secret.


### PR DESCRIPTION
Closes #91

Adds GET /v1/reporting/weekly-context with:
- dedicated TF_REPORTING_READ_TOKEN and server-owned workspace scope
- bounded deterministic aggregates with per-source freshness
- conservative mixed freshness for partial stale/no-signal data
- upper-bounded normalized timestamps and timing-resistant bearer verification
- no-store responses, no PII/raw rows/credentials, and caller override rejection
- current documentation redaction and independent Cloudflare Access runbook

Validation: 15 files / 155 tests, pnpm check, diff check.
Production requires configuring the reporting token/workspace and separate Cloudflare Access headers; Git history is intentionally not rewritten.