### PR TITLE
fix(worker): derive command authority from principal

### DIFF
--- a/cloudflare/worker/src/lib/commands/types.ts
+++ b/cloudflare/worker/src/lib/commands/types.ts
@@ -63,6 +63,19 @@ export interface CommandIntent {
   payload: Record<string, unknown>;
 }
 
+/**
+ * Server-authenticated identity used for command authorization and persistence.
+ *
+ * This is deliberately separate from CommandIntent: actor fields in the JSON
+ * body remain accepted for wire compatibility, but they are untrusted claims
+ * and never grant authority.
+ */
+export interface AuthenticatedCommandPrincipal {
+  actor_id: string;
+  actor_kind: ActorKind;
+  auth_mode: AuthMode;
+}
+
 /** What the Worker stores. */
 export interface CommandRun {
   id: string;

--- a/cloudflare/worker/src/routes/__tests__/commands-principal.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/commands-principal.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../../lib/env";
+import { makeMockDb, type MockDbHandle } from "../../lib/test-utils/mock-d1";
+import { handleV1Request } from "../v1";
+
+function commandRequest(
+  headers: HeadersInit,
+  overrides: Partial<{
+    actor_id: string;
+    actor_kind: string;
+    auth_mode: string;
+  }> = {},
+): Request {
+  return new Request("https://x/v1/commands/intent", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify({
+      id: "ts-standup",
+      actor_id: "claimed-founder",
+      actor_kind: "founder",
+      auth_mode: "cf_access",
+      correlation_id: "principal-route-test",
+      payload: {},
+      ...overrides,
+    }),
+  });
+}
+
+describe("command principal derivation", () => {
+  let mock: MockDbHandle;
+  let env: Env;
+
+  beforeEach(() => {
+    mock = makeMockDb();
+    env = {
+      TF_ENV: "test",
+      TEAMFORGE_DB: mock.db,
+      TF_CREDENTIAL_ENVELOPE_KEY: "app-token",
+      TF_INTERNAL_SHARED_SECRET: "internal-token",
+    } as Env;
+  });
+
+  it("rejects an app bearer that claims founder authority", async () => {
+    const request = commandRequest({ authorization: "Bearer app-token" });
+    const response = await handleV1Request(request, env, new URL(request.url));
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("forbidden");
+    expect(body.error.message).toContain(
+      "claimed actor_kind founder does not match authenticated actor_kind multica_service",
+    );
+    expect(mock.runs.size).toBe(0);
+  });
+
+  it("keeps an app bearer unauthorized even when its service claim matches", async () => {
+    const request = commandRequest(
+      { authorization: "Bearer app-token" },
+      { actor_kind: "multica_service", auth_mode: "app_bearer" },
+    );
+    const response = await handleV1Request(request, env, new URL(request.url));
+
+    expect(response.status).toBe(403);
+    const body = (await response.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("forbidden");
+    expect(body.error.message).toContain(
+      "authenticated actor_kind multica_service not allowed for ts-standup",
+    );
+    expect(mock.runs.size).toBe(0);
+  });
+
+  it("preserves the internal Hermes operator path with server-owned attribution", async () => {
+    const request = commandRequest({ "x-teamforge-internal-secret": "internal-token" });
+    const response = await handleV1Request(request, env, new URL(request.url));
+
+    expect(response.status).toBe(201);
+    const [run] = [...mock.runs.values()];
+    expect(run.actor_id).toBe("teamforge_internal_operator");
+    expect(run.actor_kind).toBe("founder");
+    expect(run.auth_mode).toBe("m2m");
+    expect(run.actor_id).not.toBe("claimed-founder");
+  });
+});

--- a/cloudflare/worker/src/routes/__tests__/commands.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/commands.test.ts
@@ -1,7 +1,26 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { handleCommandIntent, handleGetCommandRun, handleListCommandRuns } from "../commands";
+import {
+  handleCommandIntent as handleCommandIntentRoute,
+  handleGetCommandRun,
+  handleListCommandRuns,
+} from "../commands";
 import { makeMockDb, type MockDbHandle } from "../../lib/test-utils/mock-d1";
 import type { Env } from "../../lib/env";
+import type { AuthenticatedCommandPrincipal } from "../../lib/commands/types";
+
+const FOUNDER_PRINCIPAL: AuthenticatedCommandPrincipal = {
+  actor_id: "pid_founder",
+  actor_kind: "founder",
+  auth_mode: "cf_access",
+};
+
+function handleCommandIntent(
+  env: Env,
+  request: Request,
+  principal: AuthenticatedCommandPrincipal = FOUNDER_PRINCIPAL,
+): Promise<Response> {
+  return handleCommandIntentRoute(env, request, principal);
+}
 
 function makeReq(body: unknown): Request {
   return new Request("https://x/v1/commands/intent", {
@@ -67,10 +86,67 @@ describe("commands routes", () => {
         correlation_id: "c-2",
         payload: {},
       }),
+      {
+        actor_id: "paperclip_service",
+        actor_kind: "paperclip_agent",
+        auth_mode: "paperclip_token",
+      },
     );
     expect(res.status).toBe(403);
     const body = (await res.json()) as { ok: boolean; error: { code: string } };
     expect(body.error.code).toBe("forbidden");
+  });
+
+  it("rejects an employee principal forging founder on a founder-only command", async () => {
+    const res = await handleCommandIntent(
+      env,
+      makeReq({
+        id: "ts-standup",
+        actor_id: "forged-founder",
+        actor_kind: "founder",
+        auth_mode: "cf_access",
+        correlation_id: "c-forged-employee",
+        payload: {},
+      }),
+      {
+        actor_id: "pid_employee",
+        actor_kind: "employee",
+        auth_mode: "cf_access",
+      },
+    );
+
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string; message: string } };
+    expect(body.error.code).toBe("forbidden");
+    expect(body.error.message).toContain("authenticated actor_kind employee");
+    expect(mock.runs.size).toBe(0);
+  });
+
+  it("persists authenticated principal attribution instead of body actor claims", async () => {
+    const res = await handleCommandIntent(
+      env,
+      makeReq({
+        id: "ts-trace-signal",
+        actor_id: "forged-founder",
+        actor_kind: "employee",
+        auth_mode: "app_bearer",
+        correlation_id: "c-derived-employee",
+        payload: {},
+      }),
+      {
+        actor_id: "pid_employee",
+        actor_kind: "employee",
+        auth_mode: "cf_access",
+      },
+    );
+
+    expect(res.status).toBe(201);
+    const [run] = [...mock.runs.values()];
+    expect(run.actor_id).toBe("pid_employee");
+    expect(run.actor_kind).toBe("employee");
+    expect(run.auth_mode).toBe("cf_access");
+    expect(mock.events.every((event) => event.actor_id === "pid_employee")).toBe(true);
+    expect(mock.events.every((event) => event.actor_kind === "employee")).toBe(true);
   });
 
   it("POST /v1/commands/intent with valid ts-standup returns 201 created (downstream route)", async () => {

--- a/cloudflare/worker/src/routes/commands.ts
+++ b/cloudflare/worker/src/routes/commands.ts
@@ -2,7 +2,13 @@ import type { Env, D1DatabaseLike } from "../lib/env";
 import { jsonError, jsonOk } from "../lib/response";
 import { COMMAND_REGISTRY, getCommandSpec, isAuthorized } from "../lib/commands/registry";
 import { createRun, getRunById, listRunsByState, recordAuditEvent, transitionRun } from "../lib/commands/runs";
-import type { ActorKind, AuthMode, CommandIntent, CommandRunState } from "../lib/commands/types";
+import type {
+  ActorKind,
+  AuthenticatedCommandPrincipal,
+  AuthMode,
+  CommandIntent,
+  CommandRunState,
+} from "../lib/commands/types";
 
 const ACTOR_KINDS = new Set<ActorKind>([
   "founder",
@@ -74,7 +80,11 @@ function requireDb(
   return { ok: true, db: env.TEAMFORGE_DB };
 }
 
-export async function handleCommandIntent(env: Env, request: Request): Promise<Response> {
+export async function handleCommandIntent(
+  env: Env,
+  request: Request,
+  principal: AuthenticatedCommandPrincipal,
+): Promise<Response> {
   let body: unknown;
   try {
     body = await request.json();
@@ -100,16 +110,23 @@ export async function handleCommandIntent(env: Env, request: Request): Promise<R
       400,
     );
   }
-  // TODO(hermes-actor-kind-trust): actor_kind is currently read from the request body, which is
-  // untrusted client input. When PlexusPrincipal gains an actor_kind field (Phase 2 likely),
-  // derive actor_kind from the authenticated principal here, NOT from intent.actor_kind. Today
-  // this is acceptable because all registered commands share the founder/cofounder tier, but
-  // it becomes exploitable once multica_service- or paperclip_agent-only commands ship.
-  if (!isAuthorized(intent.id, intent.actor_kind)) {
+  if (intent.actor_kind !== principal.actor_kind) {
     return jsonError(
       {
         code: "forbidden",
-        message: `actor_kind ${intent.actor_kind} not allowed for ${intent.id}`,
+        message: `claimed actor_kind ${intent.actor_kind} does not match authenticated actor_kind ${principal.actor_kind}`,
+        retryable: false,
+      },
+      403,
+    );
+  }
+  // Body actor fields remain part of the wire contract, but all authority and
+  // persisted attribution come from the server-authenticated principal.
+  if (!isAuthorized(intent.id, principal.actor_kind)) {
+    return jsonError(
+      {
+        code: "forbidden",
+        message: `authenticated actor_kind ${principal.actor_kind} not allowed for ${intent.id}`,
         retryable: false,
       },
       403,
@@ -120,15 +137,21 @@ export async function handleCommandIntent(env: Env, request: Request): Promise<R
   if (!dbCheck.ok) return dbCheck.response;
   const db = dbCheck.db;
   const now = Date.now();
+  const authenticatedIntent: CommandIntent = {
+    ...intent,
+    actor_id: principal.actor_id,
+    actor_kind: principal.actor_kind,
+    auth_mode: principal.auth_mode,
+  };
 
   try {
-    const run = await createRun(db, intent, now);
+    const run = await createRun(db, authenticatedIntent, now);
     await recordAuditEvent(
       db,
       run.id,
       "command_received",
-      intent.actor_id,
-      intent.actor_kind,
+      principal.actor_id,
+      principal.actor_kind,
       {
         command_id: intent.id,
         correlation_id: intent.correlation_id,
@@ -140,8 +163,8 @@ export async function handleCommandIntent(env: Env, request: Request): Promise<R
       db,
       run.id,
       "run_created",
-      intent.actor_id,
-      intent.actor_kind,
+      principal.actor_id,
+      principal.actor_kind,
       null,
       now,
     );

--- a/cloudflare/worker/src/routes/v1.ts
+++ b/cloudflare/worker/src/routes/v1.ts
@@ -21,6 +21,7 @@
  */
 
 import type { Env } from "../lib/env";
+import type { AuthenticatedCommandPrincipal } from "../lib/commands/types";
 import { requireBearerAuth, requireInternalAuth } from "../lib/auth";
 import { jsonError, jsonNotImplemented, jsonOk } from "../lib/response";
 import { verifyAccessJwt } from "../lib/access";
@@ -150,6 +151,40 @@ export async function handleV1Request(request: Request, env: Env, url: URL): Pro
       env.TF_CREDENTIAL_ENVELOPE_KEY,
       "app",
     );
+  };
+
+  // Called only after requireAppOrInternalAuth succeeds. Actor claims from the
+  // request body never participate in this server-side authority mapping.
+  const resolveCommandPrincipal = (): AuthenticatedCommandPrincipal => {
+    if (plexusPrincipal) {
+      return {
+        actor_id: plexusPrincipal.identityId,
+        actor_kind: plexusPrincipal.role === "admin" ? "founder" : "employee",
+        auth_mode: "cf_access",
+      };
+    }
+
+    const providedInternal = request.headers.get("x-teamforge-internal-secret");
+    if (
+      providedInternal &&
+      env.TF_INTERNAL_SHARED_SECRET &&
+      providedInternal === env.TF_INTERNAL_SHARED_SECRET
+    ) {
+      return {
+        // The existing internal credential is the explicit Hermes/parity
+        // operator bridge. Preserve that delegated command tier, but derive it
+        // here rather than accepting a founder claim from JSON.
+        actor_id: "teamforge_internal_operator",
+        actor_kind: "founder",
+        auth_mode: "m2m",
+      };
+    }
+
+    return {
+      actor_id: "teamforge_app_service",
+      actor_kind: "multica_service",
+      auth_mode: "app_bearer",
+    };
   };
 
   // Agent feed (Paperclip bridge) — auth required, shared HMAC secret
@@ -519,7 +554,7 @@ export async function handleV1Request(request: Request, env: Env, url: URL): Pro
   if (method === "POST" && pathname === "/v1/commands/intent") {
     const authFailure = requireAppOrInternalAuth();
     if (authFailure) return authFailure;
-    return handleCommandIntent(env, request);
+    return handleCommandIntent(env, request, resolveCommandPrincipal());
   }
   // Phase B: queue interface — the cambium-bridge teamforge-consumer polls this
   // every ~5s to pick up new runs (state=created, route=downstream_multica),

--- a/docs/architecture/contracts/founder-command-registry.md
+++ b/docs/architecture/contracts/founder-command-registry.md
@@ -83,7 +83,17 @@ downstream consumers (MultiCA enqueue, Paperclip envelope).
 
 Both routes are gated by `requireAppOrInternalAuth` (CF Access JWT, m2m shared
 secret, or app Bearer). Per-command authorization is performed by the registry's
-`isAuthorized(commandId, actorKind)` helper.
+`isAuthorized(commandId, actorKind)` helper using a server-derived principal:
+
+- registered Access `admin` → `founder`
+- registered Access `employee` → `employee`
+- valid internal Hermes/parity credential → delegated `founder`
+- generic app Bearer → `multica_service` (no founder-command authority)
+
+The body still requires `actor_id`, `actor_kind`, and `auth_mode` for wire
+compatibility. Those values are untrusted claims: `actor_kind` must match the
+authenticated principal, while the Worker replaces all three before
+authorization, persistence, and audit.
 
 ### Error taxonomy
 
@@ -92,20 +102,13 @@ secret, or app Bearer). Per-command authorization is performed by the registry's
 | `bad_json` | 400 | request body is not valid JSON |
 | `invalid_intent` | 400 | missing field, or `actor_kind` / `auth_mode` not in enum, or `payload` is not an object |
 | `unknown_command` | 400 | `command_id` not in registry |
-| `forbidden` | 403 | actor_kind not in `allowed_actor_kinds` for this command |
+| `forbidden` | 403 | authenticated principal kind not in `allowed_actor_kinds` for this command |
 | `not_found` | 404 | run_id has no matching row (GET only) |
 | `database_unavailable` | 503 | `TEAMFORGE_DB` binding missing |
 | `internal_error` | 500 | unexpected D1 failure during create/audit/transition (retryable) |
 
 ## Known Limitations
 
-- **Actor-kind trust gap:** `actor_kind` is currently read from the request
-  body, which is untrusted client input. When `PlexusPrincipal` gains an
-  `actor_kind` field (Phase 2 likely), the route handler must derive
-  `actor_kind` from the authenticated principal rather than from
-  `intent.actor_kind`. Today this is acceptable because all registered commands
-  share the founder/cofounder tier; it becomes exploitable once
-  `multica_service`- or `paperclip_agent`-only commands ship.
 - **No idempotency on `correlation_id`:** two POSTs with the same
   `correlation_id` produce two distinct runs. Dedup logic is deferred to Phase
   2 if needed.

--- a/docs/architecture/contracts/multica-execution-contract.md
+++ b/docs/architecture/contracts/multica-execution-contract.md
@@ -127,11 +127,10 @@ curl -X POST https://teamforge-api.sheshnarayan-iyer.workers.dev/v1/commands/run
   forever (idempotency makes this a no-op, but it still emits an audit
   event for `in_progress`). If this proves abusable, add a `timestamp` field
   to the envelope + reject if `|now - timestamp| > 5min`.
-- **actor_kind trust gap** (carried from Phase 1): `actor_kind` on
-  `/v1/commands/intent` is still client-asserted. Closing this requires
-  extending `PlexusPrincipal` with `actor_kind` and is a recommended but
-  non-blocking follow-up — Phase 2's runtime is safe today because all
-  registered commands share the founder/cofounder tier.
+- **Command identity is server-derived.** The body-level `actor_kind` remains
+  for wire compatibility, but it cannot grant authority. The Worker maps a
+  registered Access role or verified credential class to the persisted actor;
+  generic app Bearers are service principals and cannot forge founder access.
 - **Paperclip retirement (Phase A, 2026-06-15)** removed the
   `downstream_paperclip` route and the in-Worker `paperclip-client.ts` /
   `dispatch.ts` glue. All Phase 3 commands that previously took that path


### PR DESCRIPTION
## Summary

- derive command authority and persisted attribution from the authenticated server principal
- reject forged founder claims from generic application credentials
- preserve the explicit Hermes internal operator compatibility boundary

## Verification

- `pnpm check`
- `pnpm test` — 16 files, 160 tests

## Production boundary

This PR changes authorization only. The dedicated reporting bearer rotation was completed separately and its workers.dev route now proves 401 unauthenticated / 200 authenticated.
