### PR TITLE
Recover GitHub App installations safely

### DIFF
--- a/.github/workflows/worker-ci.yml
+++ b/.github/workflows/worker-ci.yml
@@ -1,0 +1,58 @@
+name: Worker CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: worker-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  worker:
+    name: worker
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: cloudflare/worker
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: cloudflare/worker/pnpm-lock.yaml
+
+      - name: Install Worker dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check Worker
+        run: pnpm check
+
+      - name: Test GitHub control plane
+        run: >-
+          pnpm exec vitest run --config vitest.config.ts
+          src/routes/__tests__/github.test.ts
+          src/routes/__tests__/github-migration.test.ts
+
+      - name: Test Worker
+        run: pnpm test

--- a/cloudflare/worker/migrations/0015_github_webhook_diagnostics.sql
+++ b/cloudflare/worker/migrations/0015_github_webhook_diagnostics.sql
@@ -1,0 +1,15 @@
+-- Durable, normalized GitHub App authority diagnostics. Raw webhook payloads
+-- remain deliberately absent; only fields needed to explain a decision persist.
+
+ALTER TABLE github_installation_facts
+  ADD COLUMN permissions_json TEXT NOT NULL DEFAULT '{}';
+
+ALTER TABLE github_webhook_deliveries ADD COLUMN action TEXT;
+ALTER TABLE github_webhook_deliveries ADD COLUMN installation_id INTEGER;
+ALTER TABLE github_webhook_deliveries ADD COLUMN account_id INTEGER;
+ALTER TABLE github_webhook_deliveries ADD COLUMN account_login TEXT;
+ALTER TABLE github_webhook_deliveries ADD COLUMN account_type TEXT;
+ALTER TABLE github_webhook_deliveries ADD COLUMN result_reason TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_github_installation_facts_target_actor
+  ON github_installation_facts(account_id, account_type, installer_sender_id, state);

--- a/cloudflare/worker/src/routes/__tests__/github-migration.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/github-migration.test.ts
@@ -3,7 +3,7 @@ import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 
 describe("GitHub multi-installation migration", () => {
-  it("preserves a 0012 binding through 0013 and 0014 while enforcing multi-account authority", () => {
+  it("preserves a 0012 binding through 0015 while enforcing authority and adding webhook diagnostics", () => {
     const db = new DatabaseSync(":memory:");
     try {
       db.exec(`
@@ -54,6 +54,7 @@ describe("GitHub multi-installation migration", () => {
 
       db.exec(readFileSync(new URL("../../../migrations/0013_github_workspace_actors.sql", import.meta.url), "utf8"));
       db.exec(readFileSync(new URL("../../../migrations/0014_github_multi_owner_installations.sql", import.meta.url), "utf8"));
+      db.exec(readFileSync(new URL("../../../migrations/0015_github_webhook_diagnostics.sql", import.meta.url), "utf8"));
 
       expect(db.prepare(`
         SELECT workspace_id, installation_id, account_id
@@ -70,6 +71,19 @@ describe("GitHub multi-installation migration", () => {
         .map((column) => String(column.name))
         .filter((name) => name.startsWith("target_account_"));
       expect(targetColumns).toEqual(["target_account_id", "target_account_login", "target_account_type"]);
+      const deliveryColumns = db.prepare("PRAGMA table_info(github_webhook_deliveries)").all()
+        .map((column) => String(column.name));
+      expect(deliveryColumns).toEqual(expect.arrayContaining([
+        "action",
+        "installation_id",
+        "account_id",
+        "account_login",
+        "account_type",
+        "result_reason",
+      ]));
+      const factColumns = db.prepare("PRAGMA table_info(github_installation_facts)").all()
+        .map((column) => String(column.name));
+      expect(factColumns).toContain("permissions_json");
 
       db.exec(`
         INSERT INTO github_connection_states (

--- a/cloudflare/worker/src/routes/__tests__/github.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/github.test.ts
@@ -6,6 +6,16 @@ import { sha256Hex, signConnectState, verifyConnectState } from "../../lib/githu
 
 let privateKeyPem = "";
 
+const requiredInstallationPermissions = {
+  actions: "read",
+  checks: "read",
+  contents: "write",
+  issues: "read",
+  metadata: "read",
+  pull_requests: "write",
+} as const;
+const requiredInstallationPermissionsJson = JSON.stringify(requiredInstallationPermissions);
+
 beforeAll(async () => {
   const pair = await crypto.subtle.generateKey(
     { name: "RSASSA-PKCS1-v1_5", modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: "SHA-256" },
@@ -40,7 +50,7 @@ function activityDb(installationId = 42): D1DatabaseLike {
         async first<T>() {
           if (sql.includes("FROM projects WHERE id")) return ({ id: args[0] } as T);
           if (sql.includes("FROM github_workspace_installations b")) {
-            return ({ workspace_id: "ws_test", installation_id: installationId, connected_by_identity_id: "pid_admin", verified_github_user_id: 7, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
+            return ({ workspace_id: "ws_test", installation_id: installationId, connected_by_identity_id: "pid_admin", verified_github_user_id: 7, verified_github_login: "installer", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson, account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
           }
           if (sql.includes("FROM project_github_verifications v")) {
             return ({ project_id: "proj_test", workspace_id: "ws_test", installation_id: installationId, repository_id: 101, repo_owner: "thoughtseed", repo_name: "private-repo", default_branch: "main", verified_at: "2026-07-13T00:00:00.000Z", owner_login: "thoughtseed", name: "private-repo", full_name: "thoughtseed/private-repo", is_private: 1, state: "active" } as T);
@@ -49,7 +59,7 @@ function activityDb(installationId = 42): D1DatabaseLike {
         },
         async all<T>() {
           if (sql.includes("FROM github_workspace_installations b")) {
-            return { results: [{ workspace_id: "ws_test", installation_id: installationId, account_id: 8, account_login: "thoughtseed", account_type: "Organization", connected_by_identity_id: "pid_admin", verified_github_user_id: 7, verified_github_login: "installer", state: "active", repository_selection: "selected" }] as T[] };
+            return { results: [{ workspace_id: "ws_test", installation_id: installationId, account_id: 8, account_login: "thoughtseed", account_type: "Organization", connected_by_identity_id: "pid_admin", verified_github_user_id: 7, verified_github_login: "installer", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson }] as T[] };
           }
           return { results: [] as T[] };
         },
@@ -105,7 +115,7 @@ function deliveryDb(initial?: { event: string; hash: string; result: string; pro
             if (delivery) delivery.result = "ping";
           }
           if (sql.includes("result = 'failed'")) {
-            const delivery = deliveries.get(String(args[0]));
+            const delivery = deliveries.get(String(args[1] ?? args[0]));
             if (delivery) delivery.result = "failed";
           }
           return { success: true, meta: { changes: 1 } };
@@ -159,14 +169,14 @@ function writeDb(existing: Record<string, unknown> | null = null, installationId
           if (sql.includes("FROM projects WHERE id")) return ({ id: args[0] } as T);
           if (sql.includes("FROM plexus_identities")) return ({ id: "pid_admin" } as T);
           if (sql.includes("FROM github_workspace_actors")) return ({ workspace_id: "ws_test", plexus_identity_id: "pid_admin", github_user_id: 77, github_login: "installer", verified_at: "2026-07-13T00:00:00.000Z", verification_source: "oauth" } as T);
-          if (sql.includes("FROM github_workspace_installations b")) return ({ workspace_id: "ws_test", installation_id: installationId, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
+          if (sql.includes("FROM github_workspace_installations b")) return ({ workspace_id: "ws_test", installation_id: installationId, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson, account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
           if (sql.includes("FROM project_github_verifications v")) return ({ project_id: "proj_test", workspace_id: "ws_test", installation_id: installationId, repository_id: 101, repo_owner: "thoughtseed", repo_name: "private-repo", default_branch: "main", verified_at: "2026-07-13T00:00:00.000Z", owner_login: "thoughtseed", name: "private-repo", full_name: "thoughtseed/private-repo", is_private: 1, state: "active" } as T);
           if (sql.includes("FROM github_write_operations")) return (existing as T | null);
           return null;
         },
         async all<T>() {
           if (sql.includes("FROM github_workspace_installations b")) {
-            return { results: [{ workspace_id: "ws_test", installation_id: installationId, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" }] as T[] };
+            return { results: [{ workspace_id: "ws_test", installation_id: installationId, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson, account_id: 8, account_login: "thoughtseed", account_type: "Organization" }] as T[] };
           }
           return { results: [] as T[] };
         },
@@ -248,7 +258,7 @@ function reconciliationDb(
         async first<T>() {
           if (sql.includes("FROM github_connection_states")) return ({ ...state } as T);
           if (sql.includes("FROM plexus_identities")) return (actorActive ? ({ id: "pid_admin" } as T) : null);
-          if (sql.includes("FROM github_installation_facts")) return ({ installation_id: Number(args[0]), installer_sender_id: 77, account_id: organization.id, account_login: organization.login, account_type: organization.type, repository_selection: repositorySelection, state: "active" } as T);
+          if (sql.includes("FROM github_installation_facts")) return ({ installation_id: Number(args[0]), installer_sender_id: 77, account_id: organization.id, account_login: organization.login, account_type: organization.type, repository_selection: repositorySelection, permissions_json: requiredInstallationPermissionsJson, state: "active" } as T);
           if (sql.includes("FROM github_workspace_actors")) return null;
           if (sql.includes("FROM github_workspace_installations")) return null;
           return null;
@@ -263,6 +273,76 @@ function reconciliationDb(
     },
   };
   return { db, wasBound: () => bound };
+}
+
+function recoveryReconciliationDb(
+  facts: Array<{
+    installation_id: number;
+    installer_sender_id: number;
+    account_id: number;
+    account_login: string;
+    account_type: string;
+    repository_selection: string;
+    permissions_json: string;
+    state: string;
+  }>,
+  installationHint = 999,
+  hintRepairChanges = 1,
+) {
+  let boundInstallationId: number | null = null;
+  const state = {
+    nonce_hash: "nonce-recovery",
+    workspace_id: "ws_test",
+    plexus_actor_id: "pid_admin",
+    expires_at: Math.floor(Date.now() / 1000) + 600,
+    consumed_at: "now",
+    oauth_user_id: 77,
+    oauth_login: "installer",
+    oauth_verified_at: "now",
+    untrusted_installation_id: installationHint,
+    target_account_id: 8,
+    target_account_login: "thoughtseed",
+    target_account_type: "Organization",
+    status: "oauth_verified",
+  };
+  const db: D1DatabaseLike = {
+    prepare(sql: string) {
+      let args: unknown[] = [];
+      const statement = {
+        bind(...values: unknown[]) { args = values; return statement; },
+        async first<T>() {
+          if (sql.includes("FROM github_connection_states")) return ({ ...state } as T);
+          if (sql.includes("FROM plexus_identities")) return ({ id: "pid_admin" } as T);
+          if (sql.includes("FROM github_installation_facts") && sql.includes("installation_id = ?")) {
+            return ((facts.find((fact) => fact.installation_id === Number(args[0])) ?? null) as T | null);
+          }
+          if (sql.includes("FROM github_workspace_actors")) return null;
+          if (sql.includes("FROM github_workspace_installations")) return null;
+          return null;
+        },
+        async all<T>() {
+          if (sql.includes("FROM github_installation_facts") && sql.includes("account_id = ?")) {
+            return {
+              results: facts.filter((fact) => fact.account_id === Number(args[0]) &&
+                fact.account_login.toLowerCase() === String(args[1]).toLowerCase() &&
+                fact.account_type === args[2] && fact.installer_sender_id === Number(args[3]) &&
+                fact.repository_selection === "selected" && fact.state !== "deleted") as T[],
+            };
+          }
+          return { results: [] as T[] };
+        },
+        async run() {
+          if (sql.includes("SET untrusted_installation_id") && sql.includes("status = 'oauth_verified'")) {
+            return { success: true, meta: { changes: hintRepairChanges } };
+          }
+          if (sql.includes("INSERT INTO github_workspace_installations")) boundInstallationId = Number(args[1]);
+          return { success: true, meta: { changes: 1 } };
+        },
+      };
+      return statement;
+    },
+  };
+  return { db, boundInstallationId: () => boundInstallationId };
 }
 
 function connectionFlowDb(nonceHash: string) {
@@ -298,8 +378,10 @@ function connectionFlowDb(nonceHash: string) {
           return null;
         },
         async all<T>() {
-          if (sql.includes("FROM github_connection_states") && sql.includes("untrusted_installation_id")) {
-            const matches = state.untrusted_installation_id === args[0] && state.oauth_user_id === args[1] && state.status === "oauth_verified";
+          if (sql.includes("FROM github_connection_states") && sql.includes("target_account_id")) {
+            const matches = state.oauth_user_id === args[0] && state.target_account_id === args[1] &&
+              String(state.target_account_login).toLowerCase() === String(args[2]).toLowerCase() &&
+              state.target_account_type === args[3] && state.status === "oauth_verified";
             return { results: (matches ? [{ nonce_hash: state.nonce_hash }] : []) as T[] };
           }
           return { results: [] as T[] };
@@ -309,6 +391,13 @@ function connectionFlowDb(nonceHash: string) {
             const id = String(args[0]);
             if (deliveries.has(id)) return { success: true, meta: { changes: 0 } };
             deliveries.set(id, { event_name: args[1], payload_sha256: args[2], result: "processing", processing_started_at: args[4] });
+            return { success: true, meta: { changes: 1 } };
+          }
+          if (sql.includes("SET action = ?") && sql.includes("github_webhook_deliveries")) {
+            const delivery = deliveries.get(String(args[5]));
+            if (delivery) Object.assign(delivery, {
+              action: args[0], installation_id: args[1], account_id: args[2], account_login: args[3], account_type: args[4],
+            });
             return { success: true, meta: { changes: 1 } };
           }
           if (sql.includes("SET untrusted_installation_id")) {
@@ -330,11 +419,19 @@ function connectionFlowDb(nonceHash: string) {
             return { success: true, meta: { changes: 1 } };
           }
           if (sql.includes("INSERT INTO github_installation_facts")) {
-            fact = { installation_id: args[0], account_id: args[1], account_login: args[2], account_type: args[3], installer_sender_id: args[4], installer_sender_login: args[5], last_actor_id: args[6], last_actor_login: args[7], repository_selection: args[8], state: "active" };
+            fact = {
+              installation_id: args[0], account_id: args[1], account_login: args[2], account_type: args[3],
+              installer_sender_id: args[4], installer_sender_login: args[5], last_actor_id: args[6], last_actor_login: args[7],
+              repository_selection: args[8], permissions_json: args[9], state: sql.includes("'active'") ? "active" : args[10],
+              last_delivery_id: sql.includes("'active'") ? args[10] : args[11],
+            };
             return { success: true, meta: { changes: 1 } };
           }
           if (sql.includes("UPDATE github_installation_facts SET")) {
-            fact = { ...fact, account_id: args[0], account_login: args[1], account_type: args[2], repository_selection: args[5], state: args[6] };
+            fact = {
+              ...fact, account_id: args[0], account_login: args[1], account_type: args[2], repository_selection: args[5],
+              permissions_json: args[6] ?? fact?.permissions_json, state: args[7], last_delivery_id: args[8],
+            };
             return { success: true, meta: { changes: 1 } };
           }
           if (sql.includes("INSERT INTO github_workspace_installations")) {
@@ -343,12 +440,12 @@ function connectionFlowDb(nonceHash: string) {
           }
           if (sql.includes("UPDATE github_connection_states SET status = 'bound'")) state.status = "bound";
           if (sql.includes("result = 'processed'")) {
-            const delivery = deliveries.get(String(args[1]));
-            if (delivery) delivery.result = "processed";
+            const delivery = deliveries.get(String(args[2]));
+            if (delivery) { delivery.result = "processed"; delivery.result_reason = args[1]; }
           }
           if (sql.includes("result = 'failed'")) {
-            const delivery = deliveries.get(String(args[0]));
-            if (delivery) delivery.result = "failed";
+            const delivery = deliveries.get(String(args[1]));
+            if (delivery) { delivery.result = "failed"; delivery.result_reason = args[0]; }
           }
           return { success: true, meta: { changes: 1 } };
         },
@@ -375,7 +472,7 @@ function actorEnrollmentDb(
         async first<T>() {
           if (sql.includes("FROM plexus_identities")) return ({ id: "pid_admin" } as T);
           if (sql.includes("FROM github_workspace_installations b")) {
-            return ({ workspace_id: "ws_test", installation_id: installationIds[0], connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
+            return ({ workspace_id: "ws_test", installation_id: installationIds[0], connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson, account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
           }
           if (sql.includes("FROM github_actor_connection_states")) {
             if (!actorState) return null;
@@ -392,7 +489,7 @@ function actorEnrollmentDb(
         },
         async all<T>() {
           if (sql.includes("FROM github_workspace_installations b")) {
-            return { results: installationIds.map((installationId) => ({ workspace_id: "ws_test", installation_id: installationId, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" })) as T[] };
+            return { results: installationIds.map((installationId) => ({ workspace_id: "ws_test", installation_id: installationId, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson, account_id: 8, account_login: "thoughtseed", account_type: "Organization" })) as T[] };
           }
           return { results: [] as T[] };
         },
@@ -495,7 +592,7 @@ async function runInstallationConnectionFlow(
     );
     const payload = JSON.stringify({
       action: "created",
-      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: "selected" },
+      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: "selected", permissions: requiredInstallationPermissions },
       sender: { id: 77, login: "installer" },
       repositories: [],
     });
@@ -561,8 +658,8 @@ describe("GitHub App routes", () => {
 
   it("returns all workspace installations and exact allowed targets", async () => {
     const bindings = [
-      { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected" },
-      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "suspended", repository_selection: "selected" },
+      { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson },
+      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "suspended", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson },
     ];
     const db: D1DatabaseLike = {
       prepare(sql: string) {
@@ -589,6 +686,80 @@ describe("GitHub App routes", () => {
           { id: 7611727, login: "Sheshiyer", type: "User" },
           { id: 47470954, login: "psychon7", type: "User" },
         ],
+        targets: [
+          { account: { id: 8, login: "thoughtseed", type: "Organization" }, installationId: 42, status: "connected", reason: "connected" },
+          { account: { id: 7611727, login: "Sheshiyer", type: "User" }, installationId: 84, status: "suspended", reason: "installation_suspended" },
+          { account: { id: 47470954, login: "psychon7", type: "User" }, status: "unconfigured", reason: "not_connected" },
+        ],
+      },
+    });
+  });
+
+  it("reports recovery reasons for every exact target without treating an OAuth hint as authority", async () => {
+    const pendingStates = [
+      { target_account_id: 8, target_account_login: "thoughtseed", target_account_type: "Organization", status: "oauth_verified", untrusted_installation_id: 999 },
+      { target_account_id: 7611727, target_account_login: "Sheshiyer", target_account_type: "User", status: "pending_oauth", untrusted_installation_id: null },
+      { target_account_id: 47470954, target_account_login: "psychon7", target_account_type: "User", status: "oauth_verified", untrusted_installation_id: 126 },
+    ];
+    const signedFacts = [
+      { installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson, state: "active" },
+    ];
+    const db: D1DatabaseLike = {
+      prepare(sql: string) {
+        const statement = {
+          bind() { return statement; },
+          async first<T>() { return null as T | null; },
+          async all<T>() {
+            if (sql.includes("FROM github_workspace_installations b")) return { results: [] as T[] };
+            if (sql.includes("FROM github_connection_states")) return { results: pendingStates as T[] };
+            if (sql.includes("FROM github_installation_facts")) return { results: signedFacts as T[] };
+            return { results: [] as T[] };
+          },
+          async run() { return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+
+    const response = await handleGithubConnection(env(db), principal("admin"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        status: "pending",
+        targets: [
+          { account: { id: 8 }, installationId: 42, status: "forbidden", reason: "installation_hint_mismatch" },
+          { account: { id: 7611727 }, status: "pending", reason: "oauth_pending" },
+          { account: { id: 47470954 }, status: "pending", reason: "trust_anchor_missing" },
+        ],
+      },
+    });
+  });
+
+  it("keeps an exact selected installation closed until all required GitHub permissions are signed", async () => {
+    const bindings = [
+      { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", permissions_json: "{}" },
+    ];
+    const db: D1DatabaseLike = {
+      prepare(sql: string) {
+        const statement = {
+          bind() { return statement; },
+          async first<T>() { return null as T | null; },
+          async all<T>() { return { results: (sql.includes("FROM github_workspace_installations b") ? bindings : []) as T[] }; },
+          async run() { return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+
+    const response = await handleGithubConnection(env(db), principal("admin"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        status: "forbidden",
+        installations: [{ installationId: 42, status: "forbidden", reason: "permissions_incomplete" }],
+        targets: expect.arrayContaining([{ account: { id: 8, login: "thoughtseed", type: "Organization" }, installationId: 42, status: "forbidden", reason: "permissions_incomplete" }]),
       },
     });
   });
@@ -605,8 +776,8 @@ describe("GitHub App routes", () => {
 
   it("aggregates repositories across active installations with installation and account metadata", async () => {
     const bindings = [
-      { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", state: "active", repository_selection: "selected" },
-      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "selected" },
+      { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson },
+      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson },
     ];
     const db: D1DatabaseLike = {
       prepare(sql: string) {
@@ -643,7 +814,7 @@ describe("GitHub App routes", () => {
 
   it("skips active bindings with forbidden repository selection or removed allowlist authority when a valid binding remains", async () => {
     const bindings = [
-      { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", state: "active", repository_selection: "selected" },
+      { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson },
       { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "all" },
       { workspace_id: "ws_test", installation_id: 126, account_id: 999, account_login: "former-owner", account_type: "User", state: "active", repository_selection: "selected" },
     ];
@@ -1082,7 +1253,7 @@ describe("GitHub App routes", () => {
     const webhookEnv = { ...env(fixture.db), TF_GITHUB_APP_WEBHOOK_SECRET: secret };
     const created = JSON.stringify({
       action: "created",
-      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: "selected" },
+      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: "selected", permissions: { ...requiredInstallationPermissions, members: "read" } },
       sender: { id: 77, login: "installer" },
       repositories: [],
     });
@@ -1095,7 +1266,7 @@ describe("GitHub App routes", () => {
 
     const deleted = JSON.stringify({
       action: "deleted",
-      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: "selected" },
+      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: "selected", permissions: { ...requiredInstallationPermissions, members: "read" } },
       sender: { id: 77, login: "installer" },
       repositories: [{ id: 101 }],
     });
@@ -1130,6 +1301,130 @@ describe("GitHub App routes", () => {
     await expect(response.json()).resolves.toMatchObject({ data: { status: "accepted" } });
     expect(fixture.fact()).toMatchObject({ installation_id: 42, account_id: 7611727, repository_selection: "selected", state: "active" });
     expect(fixture.delivery("delivery-compact-created")).toMatchObject({ result: "processed" });
+  });
+
+  it("bootstraps an exact selected trust fact from a signed non-deletion lifecycle event and stays duplicate-idempotent", async () => {
+    const nonceHash = await sha256Hex("nonce-lifecycle-bootstrap");
+    const fixture = connectionFlowDb(nonceHash);
+    const secret = "webhook-test-secret";
+    const webhookEnv = { ...env(fixture.db), TF_GITHUB_APP_WEBHOOK_SECRET: secret };
+    const payload = JSON.stringify({
+      action: "new_permissions_accepted",
+      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: "selected", permissions: { ...requiredInstallationPermissions, members: "read" } },
+      sender: { id: 77, login: "installer" },
+      repositories: [],
+    });
+    const request = async () => handleGithubWebhook(webhookEnv, new Request("https://worker.test/v1/github/webhook", {
+      method: "POST",
+      headers: { "x-hub-signature-256": await webhookSignature(payload, secret), "x-github-delivery": "delivery-lifecycle-bootstrap", "x-github-event": "installation" },
+      body: payload,
+    }));
+
+    const first = await request();
+    expect(first.status).toBe(200);
+    expect(fixture.fact()).toMatchObject({
+      installation_id: 42,
+      account_id: 8,
+      repository_selection: "selected",
+      permissions_json: '{"actions":"read","checks":"read","contents":"write","issues":"read","members":"read","metadata":"read","pull_requests":"write"}',
+      state: "active",
+    });
+    expect(fixture.delivery("delivery-lifecycle-bootstrap")).toMatchObject({
+      action: "new_permissions_accepted",
+      installation_id: 42,
+      account_id: 8,
+      account_login: "thoughtseed",
+      account_type: "Organization",
+      result: "processed",
+      result_reason: "lifecycle_bootstrap",
+    });
+
+    const duplicate = await request();
+    expect(duplicate.status).toBe(200);
+    await expect(duplicate.json()).resolves.toMatchObject({ data: { status: "duplicate" } });
+    expect(fixture.fact()).toMatchObject({ installation_id: 42, last_delivery_id: "delivery-lifecycle-bootstrap" });
+  });
+
+  it("persists but never connects a selected lifecycle bootstrap with missing signed permissions", async () => {
+    const nonceHash = await sha256Hex("nonce-permissions-missing");
+    const fixture = connectionFlowDb(nonceHash);
+    const secret = "webhook-test-secret";
+    const payload = JSON.stringify({
+      action: "new_permissions_accepted",
+      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: "selected" },
+      sender: { id: 77, login: "installer" },
+      repositories: [],
+    });
+    const response = await handleGithubWebhook({ ...env(fixture.db), TF_GITHUB_APP_WEBHOOK_SECRET: secret }, new Request("https://worker.test/v1/github/webhook", {
+      method: "POST",
+      headers: { "x-hub-signature-256": await webhookSignature(payload, secret), "x-github-delivery": "delivery-permissions-missing", "x-github-event": "installation" },
+      body: payload,
+    }));
+    expect(response.status).toBe(200);
+    expect(fixture.fact()).toMatchObject({ permissions_json: "{}", state: "active" });
+
+    Object.assign(fixture.state, {
+      consumed_at: "now",
+      oauth_user_id: 77,
+      oauth_login: "installer",
+      oauth_verified_at: "now",
+      untrusted_installation_id: 42,
+      status: "oauth_verified",
+    });
+    await expect(reconcileBinding(env(fixture.db), nonceHash)).rejects.toMatchObject({ code: "github_installation_permissions_incomplete" });
+    expect(fixture.binding()).toBeNull();
+  });
+
+  it("preserves the last signed permission snapshot when a repository lifecycle event omits permissions", async () => {
+    const nonceHash = await sha256Hex("nonce-repository-permissions");
+    const fixture = connectionFlowDb(nonceHash);
+    const secret = "webhook-test-secret";
+    const webhookEnv = { ...env(fixture.db), TF_GITHUB_APP_WEBHOOK_SECRET: secret };
+    const send = async (deliveryId: string, eventName: string, body: Record<string, unknown>) => {
+      const payload = JSON.stringify(body);
+      return handleGithubWebhook(webhookEnv, new Request("https://worker.test/v1/github/webhook", {
+        method: "POST",
+        headers: { "x-hub-signature-256": await webhookSignature(payload, secret), "x-github-delivery": deliveryId, "x-github-event": eventName },
+        body: payload,
+      }));
+    };
+    expect((await send("delivery-permissions-created", "installation", {
+      action: "created",
+      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: "selected", permissions: requiredInstallationPermissions },
+      sender: { id: 77, login: "installer" },
+      repositories: [],
+    })).status).toBe(200);
+    expect((await send("delivery-permissions-repos", "installation_repositories", {
+      action: "added",
+      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: "selected" },
+      sender: { id: 77, login: "installer" },
+      repositories_added: [],
+      repositories_removed: [],
+    })).status).toBe(200);
+    expect(fixture.fact()).toMatchObject({ permissions_json: requiredInstallationPermissionsJson, state: "active" });
+  });
+
+  it.each([
+    ["deleted", "selected"],
+    ["new_permissions_accepted", "all"],
+  ])("does not bootstrap a missing trust fact for %s lifecycle with %s repository scope", async (action, repositorySelection) => {
+    const nonceHash = await sha256Hex(`nonce-closed-bootstrap-${action}-${repositorySelection}`);
+    const fixture = connectionFlowDb(nonceHash);
+    const secret = "webhook-test-secret";
+    const payload = JSON.stringify({
+      action,
+      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: repositorySelection },
+      sender: { id: 77, login: "installer" },
+      repositories: [],
+    });
+    const response = await handleGithubWebhook({ ...env(fixture.db), TF_GITHUB_APP_WEBHOOK_SECRET: secret }, new Request("https://worker.test/v1/github/webhook", {
+      method: "POST",
+      headers: { "x-hub-signature-256": await webhookSignature(payload, secret), "x-github-delivery": `delivery-closed-${action.replaceAll("_", "-")}-${repositorySelection}`, "x-github-event": "installation" },
+      body: payload,
+    }));
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "github_installation_untrusted" } });
+    expect(fixture.fact()).toBeNull();
   });
 
   it("rejects compact repository facts outside the signed installation account", async () => {
@@ -1252,7 +1547,7 @@ describe("GitHub App routes", () => {
           bind(...values: unknown[]) { args = values; return statement; },
           async first<T>() {
             if (sql.includes("FROM github_connection_states")) return ({ ...state } as T);
-            if (sql.includes("FROM github_installation_facts")) return ({ installation_id: Number(args[0]), installer_sender_id: 77, account_id: 8, account_login: "thoughtseed", account_type: "Organization", repository_selection: "selected", state: "active" } as T);
+            if (sql.includes("FROM github_installation_facts")) return ({ installation_id: Number(args[0]), installer_sender_id: 77, account_id: 8, account_login: "thoughtseed", account_type: "Organization", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson, state: "active" } as T);
             if (sql.includes("FROM github_workspace_actors")) return null;
             if (sql.includes("FROM plexus_identities")) return ({ id: "pid_admin" } as T);
             if (sql.includes("FROM github_workspace_installations")) return null;
@@ -1269,6 +1564,37 @@ describe("GitHub App routes", () => {
     };
     await expect(reconcileBinding(env(db), "nonce-hash")).resolves.toBe(true);
     expect(bound).toEqual([42]);
+  });
+
+  it("recovers a stale installation hint only from one exact selected signed fact", async () => {
+    const fixture = recoveryReconciliationDb([
+      { installation_id: 42, installer_sender_id: 77, account_id: 8, account_login: "thoughtseed", account_type: "Organization", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson, state: "active" },
+    ]);
+
+    await expect(reconcileBinding(env(fixture.db), "nonce-recovery")).resolves.toBe(true);
+    expect(fixture.boundInstallationId()).toBe(42);
+  });
+
+  it("fails closed when stale-hint recovery has zero or multiple exact signed facts", async () => {
+    const missing = recoveryReconciliationDb([]);
+    await expect(reconcileBinding(env(missing.db), "nonce-recovery")).resolves.toBe(false);
+    expect(missing.boundInstallationId()).toBeNull();
+
+    const ambiguous = recoveryReconciliationDb([
+      { installation_id: 42, installer_sender_id: 77, account_id: 8, account_login: "thoughtseed", account_type: "Organization", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson, state: "active" },
+      { installation_id: 84, installer_sender_id: 77, account_id: 8, account_login: "thoughtseed", account_type: "Organization", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson, state: "active" },
+    ]);
+    await expect(reconcileBinding(env(ambiguous.db), "nonce-recovery")).rejects.toMatchObject({ code: "github_connection_ambiguous" });
+    expect(ambiguous.boundInstallationId()).toBeNull();
+  });
+
+  it("does not bind after a concurrent connection-state transition wins the stale-hint repair", async () => {
+    const raced = recoveryReconciliationDb([
+      { installation_id: 42, installer_sender_id: 77, account_id: 8, account_login: "thoughtseed", account_type: "Organization", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson, state: "active" },
+    ], 999, 0);
+
+    await expect(reconcileBinding(env(raced.db), "nonce-recovery")).resolves.toBe(false);
+    expect(raced.boundInstallationId()).toBeNull();
   });
 
   it("rejects all-repositories installations and inactive initiating admins", async () => {
@@ -1317,7 +1643,7 @@ describe("GitHub App routes", () => {
           bind(...values: unknown[]) { args = values; return statement; },
           async first<T>() {
             if (sql.includes("FROM projects WHERE id")) return ({ id: args[0] } as T);
-            if (sql.includes("FROM github_workspace_installations b")) return ({ workspace_id: "ws_test", installation_id: 42, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
+            if (sql.includes("FROM github_workspace_installations b")) return ({ workspace_id: "ws_test", installation_id: 42, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson, account_id: 8, account_login: "thoughtseed", account_type: "Organization" } as T);
             if (sql.includes("FROM github_installation_repositories r")) return ({ installation_id: 42, repository_id: 101, owner_login: "thoughtseed", name: "private-repo", full_name: "thoughtseed/private-repo", is_private: 1, default_branch: "main", state: "active" } as T);
             return null;
           },

--- a/cloudflare/worker/src/routes/github.ts
+++ b/cloudflare/worker/src/routes/github.ts
@@ -72,7 +72,27 @@ interface InstallationBindingRow {
   account_login: string;
   account_type: "Organization" | "User";
   repository_selection: string;
+  permissions_json: string;
 }
+
+interface InstallationFactRow {
+  installation_id: number;
+  installer_sender_id: number;
+  account_id: number;
+  account_login: string;
+  account_type: "Organization" | "User";
+  repository_selection: string;
+  permissions_json: string;
+  state: "active" | "suspended" | "deleted";
+}
+
+type InstallationStatus = "connected" | "suspended" | "forbidden";
+type InstallationReason =
+  | "connected"
+  | "repository_scope_all"
+  | "permissions_incomplete"
+  | "installation_suspended"
+  | "installation_revoked";
 
 interface RepositoryAuthorityRow {
   installation_id: number;
@@ -134,6 +154,15 @@ interface GithubCiEvidence {
 }
 
 const PLEXUS_GITHUB_ACTOR_RETURN_URL = "plexus://github/setup/v1";
+const requiredGithubInstallationPermissions = {
+  actions: "read",
+  checks: "read",
+  contents: "write",
+  issues: "read",
+  metadata: "read",
+  pull_requests: "write",
+} as const;
+const githubPermissionRank: Record<string, number> = { read: 1, write: 2, admin: 3 };
 
 function acceptsHtml(request: Request): boolean {
   return (request.headers.get("accept") ?? "")
@@ -290,6 +319,42 @@ function isAllowedInstallationTarget(policy: GithubInstallationPolicy, value: Pi
   return Boolean(expected && expected.type === value.account_type && expected.login.toLowerCase() === value.account_login.toLowerCase());
 }
 
+function normalizeInstallationPermissions(value: unknown): string | null {
+  if (value === undefined) return null;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "{}";
+  const normalized: Record<string, string> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    const level = (value as Record<string, unknown>)[key];
+    if (/^[a-z][a-z0-9_]*$/.test(key) && typeof level === "string" && githubPermissionRank[level]) normalized[key] = level;
+  }
+  return JSON.stringify(normalized);
+}
+
+function hasRequiredInstallationPermissions(permissionsJson: string): boolean {
+  try {
+    const permissions = JSON.parse(permissionsJson) as Record<string, unknown>;
+    return Object.entries(requiredGithubInstallationPermissions).every(([name, required]) => {
+      const actual = permissions[name];
+      return typeof actual === "string" && (githubPermissionRank[actual] ?? 0) >= githubPermissionRank[required];
+    });
+  } catch {
+    return false;
+  }
+}
+
+function installationDisposition(
+  policy: GithubInstallationPolicy,
+  binding: InstallationBindingRow,
+): { status: InstallationStatus; reason: InstallationReason } {
+  if (!isAllowedInstallationTarget(policy, binding) || binding.state === "revoked") {
+    return { status: "forbidden", reason: "installation_revoked" };
+  }
+  if (binding.repository_selection !== "selected") return { status: "forbidden", reason: "repository_scope_all" };
+  if (binding.state === "suspended") return { status: "suspended", reason: "installation_suspended" };
+  if (!hasRequiredInstallationPermissions(binding.permissions_json)) return { status: "forbidden", reason: "permissions_incomplete" };
+  return { status: "connected", reason: "connected" };
+}
+
 function assertAllowedInstallationTarget(policy: GithubInstallationPolicy, value: Pick<InstallationBindingRow, "account_id" | "account_login" | "account_type">): void {
   if (!isAllowedInstallationTarget(policy, value)) {
     throw new GithubControlPlaneError("github_installation_account_forbidden", "GitHub App installation account is not allowlisted.", 403);
@@ -326,7 +391,7 @@ async function parseJsonObject(request: Request): Promise<Record<string, unknown
 async function getBindings(env: Env, workspaceId: string): Promise<InstallationBindingRow[]> {
   return queryAll<InstallationBindingRow>(
     database(env),
-    `SELECT b.*, f.account_login, f.account_type, f.repository_selection
+    `SELECT b.*, f.account_login, f.account_type, f.repository_selection, f.permissions_json
        FROM github_workspace_installations b
        JOIN github_installation_facts f ON f.installation_id = b.installation_id
       WHERE b.workspace_id = ?
@@ -338,7 +403,7 @@ async function getBindings(env: Env, workspaceId: string): Promise<InstallationB
 async function getBinding(env: Env, workspaceId: string, installationId: number): Promise<InstallationBindingRow | null> {
   return queryFirst<InstallationBindingRow>(
     database(env),
-    `SELECT b.*, f.account_login, f.account_type, f.repository_selection
+    `SELECT b.*, f.account_login, f.account_type, f.repository_selection, f.permissions_json
        FROM github_workspace_installations b
        JOIN github_installation_facts f ON f.installation_id = b.installation_id
       WHERE b.workspace_id = ? AND b.installation_id = ? LIMIT 1`,
@@ -352,6 +417,7 @@ function assertBindingIsActive(env: Env, binding: InstallationBindingRow): Insta
   if (binding.repository_selection !== "selected") throw new GithubControlPlaneError("github_repository_selection_forbidden", "GitHub App access to all repositories is forbidden.", 403);
   if (binding.state === "suspended") throw new GithubControlPlaneError("github_suspended", "The workspace GitHub App installation is suspended.", 409);
   if (binding.state !== "active") throw new GithubControlPlaneError("github_forbidden", "The workspace GitHub App installation is revoked.", 403);
+  if (!hasRequiredInstallationPermissions(binding.permissions_json)) throw new GithubControlPlaneError("github_installation_permissions_incomplete", "GitHub App installation permissions are incomplete.", 403);
   assertAllowedInstallationTarget(githubInstallationPolicy(env), binding);
   return binding;
 }
@@ -366,7 +432,8 @@ async function assertActiveBindings(env: Env, workspaceId: string): Promise<Inst
   const activeBindings = (await getBindings(env, workspaceId)).filter((binding) => binding.state === "active");
   if (activeBindings.length === 0) throw new GithubControlPlaneError("github_unconfigured", "No active GitHub App installation is connected to this workspace.", 409);
   const policy = githubInstallationPolicy(env);
-  const bindings = activeBindings.filter((binding) => binding.repository_selection === "selected" && isAllowedInstallationTarget(policy, binding));
+  const bindings = activeBindings.filter((binding) => binding.repository_selection === "selected" &&
+    hasRequiredInstallationPermissions(binding.permissions_json) && isAllowedInstallationTarget(policy, binding));
   if (bindings.length === 0) throw new GithubControlPlaneError("github_unconfigured", "No active GitHub App installation is connected to this workspace.", 409);
   return bindings;
 }
@@ -453,23 +520,47 @@ export async function reconcileBinding(env: Env, nonceHash: string): Promise<boo
   if (!state?.oauth_user_id || !state.oauth_login || !state.untrusted_installation_id || !state.target_account_id ||
     !state.target_account_login || !state.target_account_type || state.status === "rejected" || state.status === "expired") return false;
   await ensureCallbackActorStillAdmin(env, { workspace: state.workspace_id, actor: state.plexus_actor_id });
-  const fact = await queryFirst<{
-    installation_id: number;
-    installer_sender_id: number;
-    account_id: number;
-    account_login: string;
-    account_type: string;
-    repository_selection: string;
-    state: string;
-  }>(
+  let fact = await queryFirst<InstallationFactRow>(
     db,
-    "SELECT installation_id, installer_sender_id, account_id, account_login, account_type, repository_selection, state FROM github_installation_facts WHERE installation_id = ? LIMIT 1",
+    "SELECT installation_id, installer_sender_id, account_id, account_login, account_type, repository_selection, permissions_json, state FROM github_installation_facts WHERE installation_id = ? LIMIT 1",
     state.untrusted_installation_id,
   );
-  if (!fact || fact.state === "deleted") return false;
+  if (!fact || fact.state === "deleted") {
+    const candidates = await queryAll<InstallationFactRow>(
+      db,
+      `SELECT installation_id, installer_sender_id, account_id, account_login, account_type,
+              repository_selection, permissions_json, state
+         FROM github_installation_facts
+        WHERE account_id = ? AND LOWER(account_login) = LOWER(?) AND account_type = ?
+          AND installer_sender_id = ? AND repository_selection = 'selected' AND state <> 'deleted'
+        ORDER BY observed_at DESC, installation_id DESC
+        LIMIT 2`,
+      state.target_account_id,
+      state.target_account_login,
+      state.target_account_type,
+      state.oauth_user_id,
+    );
+    if (candidates.length === 0) return false;
+    if (candidates.length > 1) throw new GithubControlPlaneError("github_connection_ambiguous", "Multiple signed installations match this connection target.", 409);
+    fact = candidates[0];
+    const repairedAt = now();
+    const repaired = await executeChanges(
+      db,
+      "UPDATE github_connection_states SET untrusted_installation_id = ?, installation_hint_at = ?, updated_at = ? WHERE nonce_hash = ? AND status = 'oauth_verified'",
+      fact.installation_id,
+      repairedAt,
+      repairedAt,
+      nonceHash,
+    );
+    if (repaired !== 1) return false;
+  }
   if (fact.repository_selection !== "selected") {
     await execute(db, "UPDATE github_connection_states SET status = 'rejected', updated_at = ? WHERE nonce_hash = ?", now(), nonceHash);
     throw new GithubControlPlaneError("github_repository_selection_forbidden", "GitHub App must be installed with only selected repositories.", 403);
+  }
+  if (!hasRequiredInstallationPermissions(fact.permissions_json)) {
+    await execute(db, "UPDATE github_connection_states SET status = 'rejected', updated_at = ? WHERE nonce_hash = ?", now(), nonceHash);
+    throw new GithubControlPlaneError("github_installation_permissions_incomplete", "GitHub App installation permissions are incomplete.", 403);
   }
   if (fact.installer_sender_id !== state.oauth_user_id) {
     await execute(db, "UPDATE github_connection_states SET status = 'rejected', updated_at = ? WHERE nonce_hash = ?", now(), nonceHash);
@@ -550,24 +641,61 @@ export async function handleGithubConnection(env: Env, principal: PlexusPrincipa
     const installationPolicy = githubInstallationPolicy(env);
     const bindings = await getBindings(env, principal!.workspaceId);
     const installations = bindings.map((binding) => {
-      const allowed = isAllowedInstallationTarget(installationPolicy, binding) && binding.repository_selection === "selected";
-      const status = !allowed ? "forbidden" as const
-        : binding.state === "active" ? "connected" as const
-          : binding.state === "suspended" ? "suspended" as const : "forbidden" as const;
-      return { installationId: binding.installation_id, status, account: installationTargetOf(binding) };
+      const disposition = installationDisposition(installationPolicy, binding);
+      return { installationId: binding.installation_id, ...disposition, account: installationTargetOf(binding) };
     });
-    if (installations.length > 0) {
-      const status = installations.some((installation) => installation.status === "connected") ? "connected" as const
-        : installations.some((installation) => installation.status === "suspended") ? "suspended" as const : "forbidden" as const;
-      return jsonOk({ status, installations, allowedTargets: installationPolicy.allowedTargets });
-    }
-    const pending = await queryFirst<{ expires_at: number }>(
+    const pendingStates = await queryAll<Pick<ConnectionStateRow,
+      "target_account_id" | "target_account_login" | "target_account_type" | "status" | "untrusted_installation_id">>(
       database(env),
-      "SELECT expires_at FROM github_connection_states WHERE workspace_id = ? AND status IN ('pending_oauth', 'oauth_verified') AND expires_at > ? ORDER BY created_at DESC LIMIT 1",
+      `SELECT target_account_id, target_account_login, target_account_type, status, untrusted_installation_id
+         FROM github_connection_states
+        WHERE workspace_id = ? AND status IN ('pending_oauth', 'oauth_verified') AND expires_at > ?
+        ORDER BY created_at DESC`,
       principal!.workspaceId,
       Math.floor(Date.now() / 1000),
     );
-    return jsonOk({ status: pending ? "pending" as const : "unconfigured" as const, installations, allowedTargets: installationPolicy.allowedTargets });
+    const facts = await queryAll<InstallationFactRow>(
+      database(env),
+      `SELECT installation_id, installer_sender_id, account_id, account_login, account_type,
+              repository_selection, permissions_json, state
+         FROM github_installation_facts
+        WHERE state <> 'deleted'
+        ORDER BY observed_at DESC, installation_id DESC`,
+    );
+    const targets = installationPolicy.allowedTargets.map((account) => {
+      const binding = bindings.find((candidate) => candidate.account_id === account.id && candidate.account_type === account.type &&
+        candidate.account_login.toLowerCase() === account.login.toLowerCase());
+      if (binding) return { account, installationId: binding.installation_id, ...installationDisposition(installationPolicy, binding) };
+
+      const pending = pendingStates.find((candidate) => candidate.target_account_id === account.id &&
+        candidate.target_account_type === account.type && candidate.target_account_login?.toLowerCase() === account.login.toLowerCase());
+      if (!pending) return { account, status: "unconfigured" as const, reason: "not_connected" as const };
+      if (pending.status === "pending_oauth") return { account, status: "pending" as const, reason: "oauth_pending" as const };
+
+      const exactFacts = facts.filter((fact) => fact.account_id === account.id && fact.account_type === account.type &&
+        fact.account_login.toLowerCase() === account.login.toLowerCase());
+      const selectedFacts = exactFacts.filter((fact) => fact.repository_selection === "selected");
+      if (selectedFacts.length > 1) return { account, status: "forbidden" as const, reason: "ambiguous_installation" as const };
+      if (selectedFacts.length === 0) {
+        const allScope = exactFacts[0];
+        if (allScope) return { account, installationId: allScope.installation_id, status: "forbidden" as const, reason: "repository_scope_all" as const };
+        return { account, status: "pending" as const, reason: "trust_anchor_missing" as const };
+      }
+      const fact = selectedFacts[0];
+      if (pending.untrusted_installation_id !== fact.installation_id) {
+        return { account, installationId: fact.installation_id, status: "forbidden" as const, reason: "installation_hint_mismatch" as const };
+      }
+      if (fact.state === "suspended") return { account, installationId: fact.installation_id, status: "suspended" as const, reason: "installation_suspended" as const };
+      if (!hasRequiredInstallationPermissions(fact.permissions_json)) {
+        return { account, installationId: fact.installation_id, status: "forbidden" as const, reason: "permissions_incomplete" as const };
+      }
+      return { account, installationId: fact.installation_id, status: "pending" as const, reason: "oauth_pending" as const };
+    });
+    const status = targets.some((target) => target.status === "connected") ? "connected" as const
+      : targets.some((target) => target.status === "suspended") ? "suspended" as const
+        : targets.some((target) => target.status === "pending") ? "pending" as const
+          : targets.some((target) => target.status === "forbidden") ? "forbidden" as const : "unconfigured" as const;
+    return jsonOk({ status, installations, allowedTargets: installationPolicy.allowedTargets, targets });
   } catch (error) {
     return controlPlaneError(error);
   }
@@ -984,12 +1112,31 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
     } catch {
       throw new GithubControlPlaneError("github_webhook_payload_invalid", "GitHub webhook payload is invalid JSON.", 400);
     }
+    const action = typeof payload.action === "string" ? payload.action : null;
+    const diagnosticInstallation = payload.installation && typeof payload.installation === "object" && !Array.isArray(payload.installation)
+      ? payload.installation as Record<string, unknown> : null;
+    const diagnosticAccount = diagnosticInstallation?.account && typeof diagnosticInstallation.account === "object" && !Array.isArray(diagnosticInstallation.account)
+      ? diagnosticInstallation.account as Record<string, unknown> : null;
+    const diagnosticInstallationId = Number(diagnosticInstallation?.id);
+    const diagnosticAccountId = Number(diagnosticAccount?.id);
+    await execute(
+      db,
+      `UPDATE github_webhook_deliveries
+          SET action = ?, installation_id = ?, account_id = ?, account_login = ?, account_type = ?
+        WHERE delivery_id = ?`,
+      action,
+      Number.isSafeInteger(diagnosticInstallationId) && diagnosticInstallationId > 0 ? diagnosticInstallationId : null,
+      Number.isSafeInteger(diagnosticAccountId) && diagnosticAccountId > 0 ? diagnosticAccountId : null,
+      typeof diagnosticAccount?.login === "string" ? diagnosticAccount.login : null,
+      diagnosticAccount?.type === "Organization" || diagnosticAccount?.type === "User" ? diagnosticAccount.type : null,
+      deliveryId,
+    );
     if (eventName === "ping") {
-      await execute(db, "UPDATE github_webhook_deliveries SET processed_at = ?, result = 'ping' WHERE delivery_id = ?", now(), deliveryId);
+      await execute(db, "UPDATE github_webhook_deliveries SET processed_at = ?, result = 'ping', result_reason = 'ping' WHERE delivery_id = ?", now(), deliveryId);
       return jsonOk({ status: "accepted" as const });
     }
     if (eventName !== "installation" && eventName !== "installation_repositories") {
-      await execute(db, "UPDATE github_webhook_deliveries SET processed_at = ?, result = 'ignored' WHERE delivery_id = ?", now(), deliveryId);
+      await execute(db, "UPDATE github_webhook_deliveries SET processed_at = ?, result = 'ignored', result_reason = 'event_not_supported' WHERE delivery_id = ?", now(), deliveryId);
       return jsonOk({ status: "ignored" as const });
     }
     const installation = payload.installation as Record<string, unknown> | undefined;
@@ -1000,6 +1147,7 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
     const accountId = Number(account?.id);
     const accountType = account?.type;
     const repositorySelection = installation?.repository_selection;
+    const permissionsJson = normalizeInstallationPermissions(installation?.permissions);
     if (!Number.isSafeInteger(installationId) || installationId <= 0 || !Number.isSafeInteger(senderId) || senderId <= 0 ||
       !Number.isSafeInteger(accountId) || accountId <= 0 || !account?.login || !sender?.login ||
       (accountType !== "Organization" && accountType !== "User") ||
@@ -1012,49 +1160,70 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
       account_login: accountTarget.login,
       account_type: accountTarget.type,
     })) {
-      await execute(db, "UPDATE github_webhook_deliveries SET processed_at = ?, result = 'ignored' WHERE delivery_id = ?", now(), deliveryId);
+      await execute(db, "UPDATE github_webhook_deliveries SET processed_at = ?, result = 'ignored', result_reason = 'account_not_allowed' WHERE delivery_id = ?", now(), deliveryId);
       return jsonOk({ status: "ignored" as const });
     }
-    const action = String(payload.action ?? "");
+    const lifecycleAction = action ?? "";
     const allowedActions = eventName === "installation"
       ? new Set(["created", "deleted", "suspend", "unsuspend", "new_permissions_accepted"])
       : new Set(["added", "removed"]);
-    if (!allowedActions.has(action)) {
-      await execute(db, "UPDATE github_webhook_deliveries SET processed_at = ?, result = 'ignored' WHERE delivery_id = ?", now(), deliveryId);
+    if (!allowedActions.has(lifecycleAction)) {
+      await execute(db, "UPDATE github_webhook_deliveries SET processed_at = ?, result = 'ignored', result_reason = 'action_not_supported' WHERE delivery_id = ?", now(), deliveryId);
       return jsonOk({ status: "ignored" as const });
     }
     const observedAt = now();
-    if (eventName === "installation" && action === "created") {
+    let resultReason = "fact_updated";
+    if (eventName === "installation" && lifecycleAction === "created") {
       await execute(
         db,
         `INSERT INTO github_installation_facts
          (installation_id, account_id, account_login, account_type, installer_sender_id, installer_sender_login,
-          last_actor_id, last_actor_login, repository_selection, state, last_delivery_id, observed_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?)
+          last_actor_id, last_actor_login, repository_selection, permissions_json, state, last_delivery_id, observed_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?)
          ON CONFLICT(installation_id) DO UPDATE SET
            account_id = excluded.account_id, account_login = excluded.account_login, account_type = excluded.account_type,
            last_actor_id = excluded.last_actor_id, last_actor_login = excluded.last_actor_login,
-           repository_selection = excluded.repository_selection, last_delivery_id = excluded.last_delivery_id,
+           repository_selection = excluded.repository_selection, permissions_json = excluded.permissions_json,
+           last_delivery_id = excluded.last_delivery_id,
            observed_at = excluded.observed_at, updated_at = excluded.updated_at`,
         installationId, accountId, String(account.login), accountType,
         senderId, String(sender.login), senderId, String(sender.login),
-        repositorySelection, deliveryId, observedAt, observedAt,
+        repositorySelection, permissionsJson ?? "{}", deliveryId, observedAt, observedAt,
       );
+      resultReason = "fact_created";
     } else {
       const existingFact = await queryFirst<{ installation_id: number; state: "active" | "suspended" | "deleted" }>(db, "SELECT installation_id, state FROM github_installation_facts WHERE installation_id = ? LIMIT 1", installationId);
-      if (!existingFact) throw new GithubControlPlaneError("github_installation_untrusted", "Installation lifecycle event arrived before a signed installation.created trust anchor.", 409, true);
-      const factState = nextInstallationState(existingFact.state, eventName, action);
-      await execute(
-        db,
-        `UPDATE github_installation_facts SET
-           account_id = ?, account_login = ?, account_type = ?, last_actor_id = ?, last_actor_login = ?,
-           repository_selection = ?, state = ?, last_delivery_id = ?, observed_at = ?, updated_at = ?
-         WHERE installation_id = ?`,
-        accountId, String(account.login), accountType, senderId, String(sender.login),
-        repositorySelection, factState, deliveryId, observedAt, observedAt, installationId,
-      );
+      if (!existingFact) {
+        if (lifecycleAction === "deleted" || repositorySelection !== "selected") {
+          throw new GithubControlPlaneError("github_installation_untrusted", "Installation lifecycle event cannot bootstrap a selected non-deleted trust fact.", 409, true);
+        }
+        const initialState = lifecycleAction === "suspend" ? "suspended" : "active";
+        await execute(
+          db,
+          `INSERT INTO github_installation_facts
+           (installation_id, account_id, account_login, account_type, installer_sender_id, installer_sender_login,
+            last_actor_id, last_actor_login, repository_selection, permissions_json, state, last_delivery_id, observed_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          installationId, accountId, String(account.login), accountType,
+          senderId, String(sender.login), senderId, String(sender.login),
+          repositorySelection, permissionsJson ?? "{}", initialState, deliveryId, observedAt, observedAt,
+        );
+        resultReason = "lifecycle_bootstrap";
+      } else {
+        const factState = nextInstallationState(existingFact.state, eventName, lifecycleAction);
+        await execute(
+          db,
+          `UPDATE github_installation_facts SET
+             account_id = ?, account_login = ?, account_type = ?, last_actor_id = ?, last_actor_login = ?,
+             repository_selection = ?, permissions_json = COALESCE(?, permissions_json), state = ?,
+             last_delivery_id = ?, observed_at = ?, updated_at = ?
+           WHERE installation_id = ?`,
+          accountId, String(account.login), accountType, senderId, String(sender.login),
+          repositorySelection, permissionsJson, factState, deliveryId, observedAt, observedAt, installationId,
+        );
+      }
     }
-    const installationDeleted = eventName === "installation" && action === "deleted";
+    const installationDeleted = eventName === "installation" && lifecycleAction === "deleted";
     if (installationDeleted) {
       await execute(db, "UPDATE github_installation_repositories SET state = 'removed', updated_at = ? WHERE installation_id = ?", observedAt, installationId);
     } else {
@@ -1098,18 +1267,22 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
     const candidates = await queryAll<{ nonce_hash: string }>(
       db,
       `SELECT nonce_hash FROM github_connection_states
-        WHERE untrusted_installation_id = ? AND oauth_user_id = ? AND status = 'oauth_verified' AND expires_at > ?`,
-      installationId,
+        WHERE oauth_user_id = ? AND target_account_id = ? AND LOWER(target_account_login) = LOWER(?)
+          AND target_account_type = ? AND status = 'oauth_verified' AND expires_at > ?`,
       storedFact.installer_sender_id,
+      accountId,
+      String(account.login),
+      accountType,
       Math.floor(Date.now() / 1000),
     );
     if (candidates.length > 1) throw new GithubControlPlaneError("github_connection_ambiguous", "Multiple connection states match this installation.", 409);
     if (candidates[0]) await reconcileBinding(env, candidates[0].nonce_hash);
-    await execute(db, "UPDATE github_webhook_deliveries SET processed_at = ?, result = 'processed' WHERE delivery_id = ?", now(), deliveryId);
+    await execute(db, "UPDATE github_webhook_deliveries SET processed_at = ?, result = 'processed', result_reason = ? WHERE delivery_id = ?", now(), resultReason, deliveryId);
     return jsonOk({ status: "accepted" as const });
   } catch (error) {
     if (ownedDelivery) {
-      await execute(ownedDelivery.db, "UPDATE github_webhook_deliveries SET result = 'failed' WHERE delivery_id = ? AND result = 'processing'", ownedDelivery.id);
+      const reason = error instanceof GithubControlPlaneError ? error.code : "github_control_plane_failed";
+      await execute(ownedDelivery.db, "UPDATE github_webhook_deliveries SET result = 'failed', result_reason = ? WHERE delivery_id = ? AND result = 'processing'", reason, ownedDelivery.id);
     }
     return controlPlaneError(error);
   }


### PR DESCRIPTION
Repairs the GitHub App control plane without relaxing selected-only authority.

- returns additive per-owner status and machine-readable recovery reasons
- recovers one uniquely matching signed installation fact from a stale callback hint
- persists bounded permission and webhook diagnostics through migration 0015
- blocks authority until all six required GitHub permissions are granted
- adds always-on Worker CI with immutable action pins

Verification: Worker typecheck, 64 focused GitHub tests, 170 full tests, actionlint.