### PR TITLE
Support all-repository GitHub installations safely

### DIFF
--- a/cloudflare/worker/README.md
+++ b/cloudflare/worker/README.md
@@ -144,23 +144,15 @@ The Worker project routes are expected to separate summary and graph concerns:
 
 The desktop app persists that config into local SQLite before syncing. Display
 pages should consume the backend projections and should not hardcode repo,
-client, milestone, Huly, Clockify, or Slack assumptions.
+client, milestone, Huly, Clockify, or Slack assumptions. This legacy display
+mapping is not GitHub App authority and never filters the repository options
+returned by `GET /v1/github/repositories`.
 
 Example `TF_INTEGRATION_CONFIG_JSON`:
 
 ```json
 {
-  "github": {
-    "repos": [
-      {
-        "repo": "Sheshiyer/parkarea-aleph",
-        "displayName": "ParkArea Phase 2 - Germany Launch",
-        "clientName": "ParkArea",
-        "defaultMilestoneNumber": 1,
-        "enabled": true
-      }
-    ]
-  },
+  "github": { "repos": [] },
   "huly": { "mirrorMode": "read_only", "mirrorEnabled": true },
   "slack": {},
   "clockify": {}
@@ -216,11 +208,18 @@ numeric user ID must both match.
 GitHub delivers the `installation` and `installation_repositories` webhook
 events to every GitHub App automatically; they are not selectable in the
 optional event-subscription list. Leave unrelated optional events unchecked.
-Install the App separately on each approved account, choose **Only select
-repositories**, and select only that account's approved repositories.
-The Worker rejects the GitHub `repository_selection: all` grant and ignores
-signed public-App webhooks from non-allowlisted accounts before persisting
-installation or repository facts.
+Install the App separately on each approved account and choose either **Only
+select repositories** or **All repositories**. The Worker mirrors that user
+choice: repository discovery returns every repository accessible to the
+installation, across every connected allowlisted account. Both modes retain
+the exact account and actor allowlists, exact project binding, and per-operation
+installation tokens narrowed to the bound numeric repository ID. Unknown scope
+values fail closed. Signed public-App webhooks from non-allowlisted accounts are
+ignored before installation or repository facts are persisted. The repository
+options endpoint refreshes this installation-scoped list on every request, so
+new repositories granted to an **All repositories** installation appear without
+editing project configuration. Discovery fails closed rather than persisting a
+partial list if GitHub pagination cannot be completed.
 
 Required GitHub App repository permissions are:
 

--- a/cloudflare/worker/src/routes/__tests__/github.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/github.test.ts
@@ -829,6 +829,40 @@ describe("GitHub App routes", () => {
     vi.unstubAllGlobals();
   });
 
+  it("does not end pagination early when duplicate IDs fill a page", async () => {
+    const binding = { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "all", permissions_json: requiredInstallationPermissionsJson };
+    const db: D1DatabaseLike = {
+      prepare(sql: string) {
+        const statement = {
+          bind() { return statement; },
+          async first<T>() { return null as T | null; },
+          async all<T>() { return { results: (sql.includes("FROM github_workspace_installations b") ? [binding] : []) as T[] }; },
+          async run() { return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+    const pageOne = [
+      { id: 500, name: "repo-500", full_name: "Sheshiyer/repo-500", private: true, default_branch: "main", owner: { id: 7611727, login: "Sheshiyer" } },
+      ...Array.from({ length: 98 }, (_, index) => ({ id: 501 + index, name: `repo-${501 + index}`, full_name: `Sheshiyer/repo-${501 + index}`, private: true, default_branch: "main", owner: { id: 7611727, login: "Sheshiyer" } })),
+      { id: 500, name: "repo-500", full_name: "Sheshiyer/repo-500", private: true, default_branch: "main", owner: { id: 7611727, login: "Sheshiyer" } },
+    ];
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) return new Response(JSON.stringify({ token: "all-token", expires_at: new Date(Date.now() + 30 * 60_000).toISOString() }), { status: 201 });
+      if (url.endsWith("&page=1")) return new Response(JSON.stringify({ total_count: 100, repositories: pageOne }));
+      if (url.endsWith("&page=2")) return new Response(JSON.stringify({ total_count: 100, repositories: [{ id: 599, name: "repo-599", full_name: "Sheshiyer/repo-599", private: true, default_branch: "main", owner: { id: 7611727, login: "Sheshiyer" } }] }));
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+
+    const response = await handleGithubRepositories(env(db), principal("admin"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ data: { repositories: expect.arrayContaining([expect.objectContaining({ id: 599 })]) } });
+    expect((fetch as ReturnType<typeof vi.fn>).mock.calls.filter(([input]) => String(input).includes("/installation/repositories")).length).toBe(2);
+    vi.unstubAllGlobals();
+  });
+
   it("returns no options and retires stale facts when a selected installation grants zero repositories", async () => {
     const binding = { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson };
     const runs: Array<{ sql: string; args: unknown[] }> = [];
@@ -861,6 +895,7 @@ describe("GitHub App routes", () => {
     await expect(response.json()).resolves.toMatchObject({ data: { repositories: [] } });
     expect(runs).toEqual(expect.arrayContaining([
       expect.objectContaining({ sql: expect.stringContaining("SET state = 'removed'"), args: expect.arrayContaining([42, 101]) }),
+      expect.objectContaining({ sql: expect.stringContaining("DELETE FROM project_github_verifications"), args: [42, 101] }),
     ]));
     vi.unstubAllGlobals();
   });
@@ -1011,7 +1046,7 @@ describe("GitHub App routes", () => {
 
     expect(response.status).toBe(503);
     await expect(response.json()).resolves.toMatchObject({ error: { code: "github_repository_snapshot_failed" } });
-    expect(batches).toEqual([2]);
+    expect(batches).toEqual([3]);
     vi.unstubAllGlobals();
   });
 

--- a/cloudflare/worker/src/routes/__tests__/github.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/github.test.ts
@@ -1433,6 +1433,71 @@ describe("GitHub App routes", () => {
     vi.unstubAllGlobals();
   });
 
+  it("uses a signed installation fact for a state-less GitHub settings return without mutating authority", async () => {
+    const nonceHash = await sha256Hex("nonce-stateless-settings-return");
+    const fixture = connectionFlowDb(nonceHash);
+    const secret = "webhook-test-secret";
+    const callbackEnv = { ...env(fixture.db), TF_GITHUB_APP_WEBHOOK_SECRET: secret };
+    const payload = JSON.stringify({
+      action: "created",
+      installation: {
+        id: 42,
+        account: { id: 8, login: "thoughtseed", type: "Organization" },
+        repository_selection: "all",
+        permissions: requiredInstallationPermissions,
+      },
+      sender: { id: 77, login: "installer" },
+      repositories: [],
+    });
+    const webhook = await handleGithubWebhook(callbackEnv, new Request("https://worker.test/v1/github/webhook", {
+      method: "POST",
+      headers: {
+        "x-hub-signature-256": await webhookSignature(payload, secret),
+        "x-github-delivery": "delivery-stateless-settings-return",
+        "x-github-event": "installation",
+      },
+      body: payload,
+    }));
+    expect(webhook.status).toBe(200);
+    expect(fixture.fact()).toMatchObject({
+      installation_id: 42,
+      account_id: 8,
+      repository_selection: "all",
+      state: "active",
+    });
+    const stateBeforeCallback = { ...fixture.state };
+
+    const callbackUrl = new URL("https://worker.test/v1/github/callback?installation_id=42&setup_action=update");
+    const response = await handleGithubCallback(callbackEnv, new Request(callbackUrl), callbackUrl);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        status: "pending",
+        target: { id: 8, login: "thoughtseed", type: "Organization" },
+      },
+    });
+    expect(fixture.state).toEqual(stateBeforeCallback);
+    expect(fixture.binding()).toBeNull();
+  });
+
+  it("keeps an unverified state-less GitHub installation return retryable and fail-closed", async () => {
+    const nonceHash = await sha256Hex("nonce-stateless-installation-unverified");
+    const fixture = connectionFlowDb(nonceHash);
+    const callbackUrl = new URL("https://worker.test/v1/github/callback?installation_id=42&setup_action=install");
+
+    const response = await handleGithubCallback(env(fixture.db), new Request(callbackUrl), callbackUrl);
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        code: "github_installation_fact_pending",
+        retryable: true,
+      },
+    });
+    expect(fixture.binding()).toBeNull();
+  });
+
   it("returns a typed retryable error when the GitHub OAuth transport fails", async () => {
     const nonce = "nonce-oauth-transport";
     const nonceHash = await sha256Hex(nonce);

--- a/cloudflare/worker/src/routes/__tests__/github.test.ts
+++ b/cloudflare/worker/src/routes/__tests__/github.test.ts
@@ -326,7 +326,7 @@ function recoveryReconciliationDb(
               results: facts.filter((fact) => fact.account_id === Number(args[0]) &&
                 fact.account_login.toLowerCase() === String(args[1]).toLowerCase() &&
                 fact.account_type === args[2] && fact.installer_sender_id === Number(args[3]) &&
-                fact.repository_selection === "selected" && fact.state !== "deleted") as T[],
+                (fact.repository_selection === "selected" || fact.repository_selection === "all") && fact.state !== "deleted") as T[],
             };
           }
           return { results: [] as T[] };
@@ -658,7 +658,7 @@ describe("GitHub App routes", () => {
 
   it("returns all workspace installations and exact allowed targets", async () => {
     const bindings = [
-      { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson },
+      { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "all", permissions_json: requiredInstallationPermissionsJson },
       { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "suspended", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson },
     ];
     const db: D1DatabaseLike = {
@@ -678,8 +678,8 @@ describe("GitHub App routes", () => {
       data: {
         status: "connected",
         installations: [
-          { installationId: 42, status: "connected", account: { id: 8, login: "thoughtseed", type: "Organization" } },
-          { installationId: 84, status: "suspended", account: { id: 7611727, login: "Sheshiyer", type: "User" } },
+          { installationId: 42, repositorySelection: "all", status: "connected", account: { id: 8, login: "thoughtseed", type: "Organization" } },
+          { installationId: 84, repositorySelection: "selected", status: "suspended", account: { id: 7611727, login: "Sheshiyer", type: "User" } },
         ],
         allowedTargets: [
           { id: 8, login: "thoughtseed", type: "Organization" },
@@ -687,8 +687,8 @@ describe("GitHub App routes", () => {
           { id: 47470954, login: "psychon7", type: "User" },
         ],
         targets: [
-          { account: { id: 8, login: "thoughtseed", type: "Organization" }, installationId: 42, status: "connected", reason: "connected" },
-          { account: { id: 7611727, login: "Sheshiyer", type: "User" }, installationId: 84, status: "suspended", reason: "installation_suspended" },
+          { account: { id: 8, login: "thoughtseed", type: "Organization" }, installationId: 42, repositorySelection: "all", status: "connected", reason: "connected" },
+          { account: { id: 7611727, login: "Sheshiyer", type: "User" }, installationId: 84, repositorySelection: "selected", status: "suspended", reason: "installation_suspended" },
           { account: { id: 47470954, login: "psychon7", type: "User" }, status: "unconfigured", reason: "not_connected" },
         ],
       },
@@ -758,8 +758,8 @@ describe("GitHub App routes", () => {
     await expect(response.json()).resolves.toMatchObject({
       data: {
         status: "forbidden",
-        installations: [{ installationId: 42, status: "forbidden", reason: "permissions_incomplete" }],
-        targets: expect.arrayContaining([{ account: { id: 8, login: "thoughtseed", type: "Organization" }, installationId: 42, status: "forbidden", reason: "permissions_incomplete" }]),
+        installations: [{ installationId: 42, repositorySelection: "selected", status: "forbidden", reason: "permissions_incomplete" }],
+        targets: expect.arrayContaining([{ account: { id: 8, login: "thoughtseed", type: "Organization" }, installationId: 42, repositorySelection: "selected", status: "forbidden", reason: "permissions_incomplete" }]),
       },
     });
   });
@@ -777,7 +777,7 @@ describe("GitHub App routes", () => {
   it("aggregates repositories across active installations with installation and account metadata", async () => {
     const bindings = [
       { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson },
-      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson },
+      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "all", permissions_json: requiredInstallationPermissionsJson },
     ];
     const db: D1DatabaseLike = {
       prepare(sql: string) {
@@ -790,6 +790,14 @@ describe("GitHub App routes", () => {
         return statement;
       },
     };
+    const firstUserPage = Array.from({ length: 100 }, (_, index) => ({
+      id: 200 + index,
+      name: `private-${String(index).padStart(3, "0")}`,
+      full_name: `Sheshiyer/private-${String(index).padStart(3, "0")}`,
+      private: true,
+      default_branch: "main",
+      owner: { id: 7611727, login: "Sheshiyer" },
+    }));
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
       if (url.includes("/app/installations/42/access_tokens")) return new Response(JSON.stringify({ token: "org-token", expires_at: new Date(Date.now() + 30 * 60_000).toISOString() }), { status: 201 });
@@ -797,8 +805,14 @@ describe("GitHub App routes", () => {
       if (url.includes("/installation/repositories") && new Headers(init?.headers).get("authorization") === "Bearer org-token") {
         return new Response(JSON.stringify({ repositories: [{ id: 101, name: "plexus", full_name: "thoughtseed/plexus", private: true, default_branch: "main", owner: { id: 8, login: "thoughtseed" } }] }));
       }
-      if (url.includes("/installation/repositories")) {
-        return new Response(JSON.stringify({ repositories: [{ id: 202, name: "parkarea", full_name: "Sheshiyer/parkarea", private: true, default_branch: "main", owner: { id: 7611727, login: "Sheshiyer" } }] }));
+      if (url.includes("/installation/repositories") && url.endsWith("&page=1")) {
+        return new Response(JSON.stringify({ repositories: firstUserPage }));
+      }
+      if (url.includes("/installation/repositories") && url.endsWith("&page=2")) {
+        return new Response(JSON.stringify({ repositories: [
+          firstUserPage[0],
+          { id: 400, name: "private-final", full_name: "Sheshiyer/private-final", private: true, default_branch: "main", owner: { id: 7611727, login: "Sheshiyer" } },
+        ] }));
       }
       throw new Error(`unexpected fetch ${url}`);
     }));
@@ -807,15 +821,204 @@ describe("GitHub App routes", () => {
     const payload = await response.json() as { data: { repositories: Array<Record<string, unknown>> } };
     expect(payload.data.repositories).toEqual(expect.arrayContaining([
       expect.objectContaining({ id: 101, installationId: 42, account: { id: 8, login: "thoughtseed", type: "Organization" } }),
-      expect.objectContaining({ id: 202, installationId: 84, account: { id: 7611727, login: "Sheshiyer", type: "User" } }),
+      expect.objectContaining({ id: 400, installationId: 84, repositorySelection: "all", account: { id: 7611727, login: "Sheshiyer", type: "User" } }),
+    ]));
+    expect(payload.data.repositories).toHaveLength(102);
+    expect(payload.data.repositories[0]).toMatchObject({ fullName: "Sheshiyer/private-000" });
+    expect(payload.data.repositories.at(-1)).toMatchObject({ fullName: "thoughtseed/plexus" });
+    vi.unstubAllGlobals();
+  });
+
+  it("returns no options and retires stale facts when a selected installation grants zero repositories", async () => {
+    const binding = { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson };
+    const runs: Array<{ sql: string; args: unknown[] }> = [];
+    const db: D1DatabaseLike = {
+      prepare(sql: string) {
+        let args: unknown[] = [];
+        const statement = {
+          bind(...values: unknown[]) { args = values; return statement; },
+          async first<T>() { return null as T | null; },
+          async all<T>() {
+            if (sql.includes("FROM github_workspace_installations b")) return { results: [binding] as T[] };
+            if (sql.includes("SELECT repository_id FROM github_installation_repositories")) return { results: [{ repository_id: 101 }] as T[] };
+            return { results: [] as T[] };
+          },
+          async run() { runs.push({ sql, args: [...args] }); return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) return new Response(JSON.stringify({ token: "selected-token", expires_at: new Date(Date.now() + 30 * 60_000).toISOString() }), { status: 201 });
+      if (url.includes("/installation/repositories")) return new Response(JSON.stringify({ repositories: [] }));
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+
+    const response = await handleGithubRepositories(env(db), principal("admin"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ data: { repositories: [] } });
+    expect(runs).toEqual(expect.arrayContaining([
+      expect.objectContaining({ sql: expect.stringContaining("SET state = 'removed'"), args: expect.arrayContaining([42, 101]) }),
     ]));
     vi.unstubAllGlobals();
   });
 
-  it("skips active bindings with forbidden repository selection or removed allowlist authority when a valid binding remains", async () => {
+  it("does not persist a partial repository snapshot when pagination fails", async () => {
+    const binding = { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "all", permissions_json: requiredInstallationPermissionsJson };
+    const runs: Array<{ sql: string; args: unknown[] }> = [];
+    const db: D1DatabaseLike = {
+      prepare(sql: string) {
+        let args: unknown[] = [];
+        const statement = {
+          bind(...values: unknown[]) { args = values; return statement; },
+          async first<T>() { return null as T | null; },
+          async all<T>() { return { results: (sql.includes("FROM github_workspace_installations b") ? [binding] : []) as T[] }; },
+          async run() { runs.push({ sql, args: [...args] }); return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      id: 500 + index,
+      name: `partial-${index}`,
+      full_name: `Sheshiyer/partial-${index}`,
+      private: true,
+      default_branch: "main",
+      owner: { id: 7611727, login: "Sheshiyer" },
+    }));
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) return new Response(JSON.stringify({ token: "all-token", expires_at: new Date(Date.now() + 30 * 60_000).toISOString() }), { status: 201 });
+      if (url.endsWith("&page=1")) return new Response(JSON.stringify({ repositories: firstPage }));
+      if (url.endsWith("&page=2")) return new Response(JSON.stringify({ message: "temporary failure" }), { status: 503 });
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+
+    const response = await handleGithubRepositories(env(db), principal("admin"));
+
+    expect(response.status).toBe(503);
+    expect(runs).toHaveLength(0);
+    vi.unstubAllGlobals();
+  });
+
+  it("fails closed when repository pagination reaches the safe limit", async () => {
+    const binding = { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "all", permissions_json: requiredInstallationPermissionsJson };
+    const runs: Array<{ sql: string; args: unknown[] }> = [];
+    const db: D1DatabaseLike = {
+      prepare(sql: string) {
+        let args: unknown[] = [];
+        const statement = {
+          bind(...values: unknown[]) { args = values; return statement; },
+          async first<T>() { return null as T | null; },
+          async all<T>() { return { results: (sql.includes("FROM github_workspace_installations b") ? [binding] : []) as T[] }; },
+          async run() { runs.push({ sql, args: [...args] }); return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) return new Response(JSON.stringify({ token: "all-token", expires_at: new Date(Date.now() + 30 * 60_000).toISOString() }), { status: 201 });
+      if (url.includes("/installation/repositories")) {
+        const page = Number(new URL(url).searchParams.get("page"));
+        return new Response(JSON.stringify({
+          total_count: 10_001,
+          repositories: Array.from({ length: 100 }, (_, index) => ({
+            id: page * 100 + index + 1,
+            name: `repo-${page}-${index}`,
+            full_name: `Sheshiyer/repo-${page}-${index}`,
+            private: true,
+            default_branch: "main",
+            owner: { id: 7611727, login: "Sheshiyer" },
+          })),
+        }));
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+
+    const response = await handleGithubRepositories(env(db), principal("admin"));
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "github_repository_discovery_incomplete" } });
+    expect(runs).toHaveLength(0);
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects contradictory duplicate repository identities before touching cache authority", async () => {
+    const binding = { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "all", permissions_json: requiredInstallationPermissionsJson };
+    const runs: string[] = [];
+    const db: D1DatabaseLike = {
+      prepare(sql: string) {
+        const statement = {
+          bind() { return statement; },
+          async first<T>() { return null as T | null; },
+          async all<T>() { return { results: (sql.includes("FROM github_workspace_installations b") ? [binding] : []) as T[] }; },
+          async run() { runs.push(sql); return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) return new Response(JSON.stringify({ token: "all-token", expires_at: new Date(Date.now() + 30 * 60_000).toISOString() }), { status: 201 });
+      if (url.includes("/installation/repositories")) return new Response(JSON.stringify({ repositories: [
+        { id: 101, name: "private-repo", full_name: "Sheshiyer/private-repo", private: true, default_branch: "main", owner: { id: 7611727, login: "Sheshiyer" } },
+        { id: 101, name: "renamed-repo", full_name: "Sheshiyer/renamed-repo", private: true, default_branch: "main", owner: { id: 7611727, login: "Sheshiyer" } },
+      ] }));
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+
+    const response = await handleGithubRepositories(env(db), principal("admin"));
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "github_repository_identity_conflict" } });
+    expect(runs).toHaveLength(0);
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the prior cache snapshot when the atomic repository batch fails", async () => {
+    const binding = { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "all", permissions_json: requiredInstallationPermissionsJson };
+    const batches: number[] = [];
+    const db: D1DatabaseLike & { batch(statements: Array<{ run(): Promise<unknown> }>): Promise<unknown[]> } = {
+      prepare(sql: string) {
+        const statement = {
+          bind() { return statement; },
+          async first<T>() { return null as T | null; },
+          async all<T>() {
+            if (sql.includes("FROM github_workspace_installations b")) return { results: [binding] as T[] };
+            if (sql.includes("SELECT repository_id FROM github_installation_repositories")) return { results: [{ repository_id: 999 }] as T[] };
+            return { results: [] as T[] };
+          },
+          async run() { return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+      async batch(statements) {
+        batches.push(statements.length);
+        throw new Error("D1 batch unavailable");
+      },
+    };
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) return new Response(JSON.stringify({ token: "all-token", expires_at: new Date(Date.now() + 30 * 60_000).toISOString() }), { status: 201 });
+      if (url.includes("/installation/repositories")) return new Response(JSON.stringify({ repositories: [{ id: 101, name: "private-repo", full_name: "Sheshiyer/private-repo", private: true, default_branch: "main", owner: { id: 7611727, login: "Sheshiyer" } }] }));
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+
+    const response = await handleGithubRepositories(env(db), principal("admin"));
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toMatchObject({ error: { code: "github_repository_snapshot_failed" } });
+    expect(batches).toEqual([2]);
+    vi.unstubAllGlobals();
+  });
+
+  it("skips active bindings with unsupported repository selection or removed allowlist authority when a valid binding remains", async () => {
     const bindings = [
       { workspace_id: "ws_test", installation_id: 42, account_id: 8, account_login: "thoughtseed", account_type: "Organization", state: "active", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson },
-      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "all" },
+      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "unexpected" },
       { workspace_id: "ws_test", installation_id: 126, account_id: 999, account_login: "former-owner", account_type: "User", state: "active", repository_selection: "selected" },
     ];
     const db: D1DatabaseLike = {
@@ -854,9 +1057,9 @@ describe("GitHub App routes", () => {
     vi.unstubAllGlobals();
   });
 
-  it("fails closed when no active binding has selected repositories and current allowlist authority", async () => {
+  it("fails closed when no active binding has supported repository selection and current allowlist authority", async () => {
     const bindings = [
-      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "all" },
+      { workspace_id: "ws_test", installation_id: 84, account_id: 7611727, account_login: "Sheshiyer", account_type: "User", state: "active", repository_selection: "unexpected" },
       { workspace_id: "ws_test", installation_id: 126, account_id: 999, account_login: "former-owner", account_type: "User", state: "active", repository_selection: "selected" },
     ];
     const db: D1DatabaseLike = {
@@ -1303,20 +1506,20 @@ describe("GitHub App routes", () => {
     expect(fixture.delivery("delivery-compact-created")).toMatchObject({ result: "processed" });
   });
 
-  it("bootstraps an exact selected trust fact from a signed non-deletion lifecycle event and stays duplicate-idempotent", async () => {
-    const nonceHash = await sha256Hex("nonce-lifecycle-bootstrap");
+  it.each(["selected", "all"])("bootstraps an exact %s trust fact from a signed non-deletion lifecycle event", async (repositorySelection) => {
+    const nonceHash = await sha256Hex(`nonce-lifecycle-bootstrap-${repositorySelection}`);
     const fixture = connectionFlowDb(nonceHash);
     const secret = "webhook-test-secret";
     const webhookEnv = { ...env(fixture.db), TF_GITHUB_APP_WEBHOOK_SECRET: secret };
     const payload = JSON.stringify({
       action: "new_permissions_accepted",
-      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: "selected", permissions: { ...requiredInstallationPermissions, members: "read" } },
+      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, repository_selection: repositorySelection, permissions: { ...requiredInstallationPermissions, members: "read" } },
       sender: { id: 77, login: "installer" },
       repositories: [],
     });
     const request = async () => handleGithubWebhook(webhookEnv, new Request("https://worker.test/v1/github/webhook", {
       method: "POST",
-      headers: { "x-hub-signature-256": await webhookSignature(payload, secret), "x-github-delivery": "delivery-lifecycle-bootstrap", "x-github-event": "installation" },
+      headers: { "x-hub-signature-256": await webhookSignature(payload, secret), "x-github-delivery": `delivery-lifecycle-bootstrap-${repositorySelection}`, "x-github-event": "installation" },
       body: payload,
     }));
 
@@ -1325,11 +1528,11 @@ describe("GitHub App routes", () => {
     expect(fixture.fact()).toMatchObject({
       installation_id: 42,
       account_id: 8,
-      repository_selection: "selected",
+      repository_selection: repositorySelection,
       permissions_json: '{"actions":"read","checks":"read","contents":"write","issues":"read","members":"read","metadata":"read","pull_requests":"write"}',
       state: "active",
     });
-    expect(fixture.delivery("delivery-lifecycle-bootstrap")).toMatchObject({
+    expect(fixture.delivery(`delivery-lifecycle-bootstrap-${repositorySelection}`)).toMatchObject({
       action: "new_permissions_accepted",
       installation_id: 42,
       account_id: 8,
@@ -1342,7 +1545,7 @@ describe("GitHub App routes", () => {
     const duplicate = await request();
     expect(duplicate.status).toBe(200);
     await expect(duplicate.json()).resolves.toMatchObject({ data: { status: "duplicate" } });
-    expect(fixture.fact()).toMatchObject({ installation_id: 42, last_delivery_id: "delivery-lifecycle-bootstrap" });
+    expect(fixture.fact()).toMatchObject({ installation_id: 42, last_delivery_id: `delivery-lifecycle-bootstrap-${repositorySelection}` });
   });
 
   it("persists but never connects a selected lifecycle bootstrap with missing signed permissions", async () => {
@@ -1406,7 +1609,6 @@ describe("GitHub App routes", () => {
 
   it.each([
     ["deleted", "selected"],
-    ["new_permissions_accepted", "all"],
   ])("does not bootstrap a missing trust fact for %s lifecycle with %s repository scope", async (action, repositorySelection) => {
     const nonceHash = await sha256Hex(`nonce-closed-bootstrap-${action}-${repositorySelection}`);
     const fixture = connectionFlowDb(nonceHash);
@@ -1566,9 +1768,9 @@ describe("GitHub App routes", () => {
     expect(bound).toEqual([42]);
   });
 
-  it("recovers a stale installation hint only from one exact selected signed fact", async () => {
+  it.each(["selected", "all"])("recovers a stale installation hint from one exact %s signed fact", async (repositorySelection) => {
     const fixture = recoveryReconciliationDb([
-      { installation_id: 42, installer_sender_id: 77, account_id: 8, account_login: "thoughtseed", account_type: "Organization", repository_selection: "selected", permissions_json: requiredInstallationPermissionsJson, state: "active" },
+      { installation_id: 42, installer_sender_id: 77, account_id: 8, account_login: "thoughtseed", account_type: "Organization", repository_selection: repositorySelection, permissions_json: requiredInstallationPermissionsJson, state: "active" },
     ]);
 
     await expect(reconcileBinding(env(fixture.db), "nonce-recovery")).resolves.toBe(true);
@@ -1597,10 +1799,10 @@ describe("GitHub App routes", () => {
     expect(raced.boundInstallationId()).toBeNull();
   });
 
-  it("rejects all-repositories installations and inactive initiating admins", async () => {
+  it("binds all-repositories installations but rejects inactive initiating admins", async () => {
     const allRepositories = reconciliationDb("all", true);
-    await expect(reconcileBinding(env(allRepositories.db), "nonce-hash")).rejects.toMatchObject({ code: "github_repository_selection_forbidden" });
-    expect(allRepositories.wasBound()).toBe(false);
+    await expect(reconcileBinding(env(allRepositories.db), "nonce-hash")).resolves.toBe(true);
+    expect(allRepositories.wasBound()).toBe(true);
 
     const inactiveAdmin = reconciliationDb("selected", false);
     await expect(reconcileBinding(env(inactiveAdmin.db), "nonce-hash")).rejects.toMatchObject({ code: "github_forbidden" });
@@ -1617,11 +1819,11 @@ describe("GitHub App routes", () => {
     expect(fixture.wasBound()).toBe(false);
   });
 
-  it.each([undefined, "unexpected"])("fails closed when signed repository_selection is %s", async (repositorySelection) => {
+  it.each([undefined, null, "", "All", "unexpected"])("fails closed when signed repository_selection is %s", async (repositorySelection) => {
     const secret = "webhook-test-secret";
     const payload = JSON.stringify({
       action: "created",
-      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, ...(repositorySelection ? { repository_selection: repositorySelection } : {}) },
+      installation: { id: 42, account: { id: 8, login: "thoughtseed", type: "Organization" }, ...(repositorySelection !== undefined ? { repository_selection: repositorySelection } : {}) },
       sender: { id: 77, login: "installer" },
       repositories: [],
     });
@@ -1633,6 +1835,46 @@ describe("GitHub App routes", () => {
     }));
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toMatchObject({ error: { code: "github_webhook_payload_invalid" } });
+  });
+
+  it("links an all-scope discovered repository to a project by numeric identity", async () => {
+    const runs: string[] = [];
+    const db: D1DatabaseLike = {
+      prepare(sql: string) {
+        let args: unknown[] = [];
+        const statement = {
+          bind(...values: unknown[]) { args = values; return statement; },
+          async first<T>() {
+            if (sql.includes("FROM projects WHERE id")) return ({ id: args[0] } as T);
+            if (sql.includes("FROM github_workspace_installations b")) return ({ workspace_id: "ws_test", installation_id: 84, connected_by_identity_id: "pid_admin", verified_github_user_id: 77, verified_github_login: "installer", state: "active", repository_selection: "all", permissions_json: requiredInstallationPermissionsJson, account_id: 7611727, account_login: "Sheshiyer", account_type: "User" } as T);
+            if (sql.includes("FROM github_installation_repositories r")) return ({ installation_id: 84, repository_id: 101, owner_login: "Sheshiyer", name: "private-repo", full_name: "Sheshiyer/private-repo", is_private: 1, default_branch: "main", state: "active" } as T);
+            return null;
+          },
+          async all<T>() { return { results: [] as T[] }; },
+          async run() { runs.push(sql); return { success: true, meta: { changes: 1 } }; },
+        };
+        return statement;
+      },
+    };
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/access_tokens")) return new Response(JSON.stringify({ token: "scoped", expires_at: new Date(Date.now() + 30 * 60_000).toISOString() }), { status: 201 });
+      if (url.includes("/repos/Sheshiyer/private-repo")) return new Response(JSON.stringify({ id: 101, name: "private-repo", full_name: "Sheshiyer/private-repo", private: true, default_branch: "main", owner: { login: "Sheshiyer", id: 7611727 } }));
+      throw new Error(`unexpected fetch ${url}`);
+    }));
+
+    const request = new Request("https://worker.test/v1/projects/proj_test/github-repo/verify", {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ installationId: 84, repositoryId: 101 }),
+    });
+    const response = await handleGithubRepoVerify(env(db), request, "proj_test", principal("admin"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ data: {
+      status: "verified",
+      repository: { id: 101, repositorySelection: "all", installationId: 84 },
+    } });
+    expect(runs.some((sql) => sql.includes("INSERT INTO project_github_verifications"))).toBe(true);
+    vi.unstubAllGlobals();
   });
 
   it("rejects numeric repository identity mismatches returned by GitHub", async () => {

--- a/cloudflare/worker/src/routes/github.ts
+++ b/cloudflare/worker/src/routes/github.ts
@@ -61,6 +61,11 @@ interface GithubInstallationPolicy {
   allowedTargetById: Map<number, GithubInstallationAccountTarget>;
 }
 
+type GithubRepositorySelection = "selected" | "all";
+
+const GITHUB_REPOSITORY_PAGE_SIZE = 100;
+const GITHUB_REPOSITORY_PAGE_LIMIT = 100;
+
 interface InstallationBindingRow {
   workspace_id: string;
   installation_id: number;
@@ -89,7 +94,7 @@ interface InstallationFactRow {
 type InstallationStatus = "connected" | "suspended" | "forbidden";
 type InstallationReason =
   | "connected"
-  | "repository_scope_all"
+  | "repository_selection_invalid"
   | "permissions_incomplete"
   | "installation_suspended"
   | "installation_revoked";
@@ -342,6 +347,10 @@ function hasRequiredInstallationPermissions(permissionsJson: string): boolean {
   }
 }
 
+function githubRepositorySelection(value: unknown): GithubRepositorySelection | null {
+  return value === "selected" || value === "all" ? value : null;
+}
+
 function installationDisposition(
   policy: GithubInstallationPolicy,
   binding: InstallationBindingRow,
@@ -349,7 +358,7 @@ function installationDisposition(
   if (!isAllowedInstallationTarget(policy, binding) || binding.state === "revoked") {
     return { status: "forbidden", reason: "installation_revoked" };
   }
-  if (binding.repository_selection !== "selected") return { status: "forbidden", reason: "repository_scope_all" };
+  if (!githubRepositorySelection(binding.repository_selection)) return { status: "forbidden", reason: "repository_selection_invalid" };
   if (binding.state === "suspended") return { status: "suspended", reason: "installation_suspended" };
   if (!hasRequiredInstallationPermissions(binding.permissions_json)) return { status: "forbidden", reason: "permissions_incomplete" };
   return { status: "connected", reason: "connected" };
@@ -414,7 +423,7 @@ async function getBinding(env: Env, workspaceId: string, installationId: number)
 
 function assertBindingIsActive(env: Env, binding: InstallationBindingRow): InstallationBindingRow {
   if (!binding) throw new GithubControlPlaneError("github_unconfigured", "No GitHub App installation is connected to this workspace.", 409);
-  if (binding.repository_selection !== "selected") throw new GithubControlPlaneError("github_repository_selection_forbidden", "GitHub App access to all repositories is forbidden.", 403);
+  if (!githubRepositorySelection(binding.repository_selection)) throw new GithubControlPlaneError("github_repository_selection_forbidden", "GitHub App repository selection is unsupported.", 403);
   if (binding.state === "suspended") throw new GithubControlPlaneError("github_suspended", "The workspace GitHub App installation is suspended.", 409);
   if (binding.state !== "active") throw new GithubControlPlaneError("github_forbidden", "The workspace GitHub App installation is revoked.", 403);
   if (!hasRequiredInstallationPermissions(binding.permissions_json)) throw new GithubControlPlaneError("github_installation_permissions_incomplete", "GitHub App installation permissions are incomplete.", 403);
@@ -432,7 +441,7 @@ async function assertActiveBindings(env: Env, workspaceId: string): Promise<Inst
   const activeBindings = (await getBindings(env, workspaceId)).filter((binding) => binding.state === "active");
   if (activeBindings.length === 0) throw new GithubControlPlaneError("github_unconfigured", "No active GitHub App installation is connected to this workspace.", 409);
   const policy = githubInstallationPolicy(env);
-  const bindings = activeBindings.filter((binding) => binding.repository_selection === "selected" &&
+  const bindings = activeBindings.filter((binding) => githubRepositorySelection(binding.repository_selection) !== null &&
     hasRequiredInstallationPermissions(binding.permissions_json) && isAllowedInstallationTarget(policy, binding));
   if (bindings.length === 0) throw new GithubControlPlaneError("github_unconfigured", "No active GitHub App installation is connected to this workspace.", 409);
   return bindings;
@@ -532,7 +541,7 @@ export async function reconcileBinding(env: Env, nonceHash: string): Promise<boo
               repository_selection, permissions_json, state
          FROM github_installation_facts
         WHERE account_id = ? AND LOWER(account_login) = LOWER(?) AND account_type = ?
-          AND installer_sender_id = ? AND repository_selection = 'selected' AND state <> 'deleted'
+          AND installer_sender_id = ? AND repository_selection IN ('selected', 'all') AND state <> 'deleted'
         ORDER BY observed_at DESC, installation_id DESC
         LIMIT 2`,
       state.target_account_id,
@@ -554,9 +563,9 @@ export async function reconcileBinding(env: Env, nonceHash: string): Promise<boo
     );
     if (repaired !== 1) return false;
   }
-  if (fact.repository_selection !== "selected") {
+  if (!githubRepositorySelection(fact.repository_selection)) {
     await execute(db, "UPDATE github_connection_states SET status = 'rejected', updated_at = ? WHERE nonce_hash = ?", now(), nonceHash);
-    throw new GithubControlPlaneError("github_repository_selection_forbidden", "GitHub App must be installed with only selected repositories.", 403);
+    throw new GithubControlPlaneError("github_repository_selection_forbidden", "GitHub App repository selection is unsupported.", 403);
   }
   if (!hasRequiredInstallationPermissions(fact.permissions_json)) {
     await execute(db, "UPDATE github_connection_states SET status = 'rejected', updated_at = ? WHERE nonce_hash = ?", now(), nonceHash);
@@ -642,7 +651,13 @@ export async function handleGithubConnection(env: Env, principal: PlexusPrincipa
     const bindings = await getBindings(env, principal!.workspaceId);
     const installations = bindings.map((binding) => {
       const disposition = installationDisposition(installationPolicy, binding);
-      return { installationId: binding.installation_id, ...disposition, account: installationTargetOf(binding) };
+      const repositorySelection = githubRepositorySelection(binding.repository_selection);
+      return {
+        installationId: binding.installation_id,
+        ...(repositorySelection ? { repositorySelection } : {}),
+        ...disposition,
+        account: installationTargetOf(binding),
+      };
     });
     const pendingStates = await queryAll<Pick<ConnectionStateRow,
       "target_account_id" | "target_account_login" | "target_account_type" | "status" | "untrusted_installation_id">>(
@@ -665,7 +680,15 @@ export async function handleGithubConnection(env: Env, principal: PlexusPrincipa
     const targets = installationPolicy.allowedTargets.map((account) => {
       const binding = bindings.find((candidate) => candidate.account_id === account.id && candidate.account_type === account.type &&
         candidate.account_login.toLowerCase() === account.login.toLowerCase());
-      if (binding) return { account, installationId: binding.installation_id, ...installationDisposition(installationPolicy, binding) };
+      if (binding) {
+        const repositorySelection = githubRepositorySelection(binding.repository_selection);
+        return {
+          account,
+          installationId: binding.installation_id,
+          ...(repositorySelection ? { repositorySelection } : {}),
+          ...installationDisposition(installationPolicy, binding),
+        };
+      }
 
       const pending = pendingStates.find((candidate) => candidate.target_account_id === account.id &&
         candidate.target_account_type === account.type && candidate.target_account_login?.toLowerCase() === account.login.toLowerCase());
@@ -674,22 +697,23 @@ export async function handleGithubConnection(env: Env, principal: PlexusPrincipa
 
       const exactFacts = facts.filter((fact) => fact.account_id === account.id && fact.account_type === account.type &&
         fact.account_login.toLowerCase() === account.login.toLowerCase());
-      const selectedFacts = exactFacts.filter((fact) => fact.repository_selection === "selected");
-      if (selectedFacts.length > 1) return { account, status: "forbidden" as const, reason: "ambiguous_installation" as const };
-      if (selectedFacts.length === 0) {
-        const allScope = exactFacts[0];
-        if (allScope) return { account, installationId: allScope.installation_id, status: "forbidden" as const, reason: "repository_scope_all" as const };
+      const supportedFacts = exactFacts.filter((fact) => githubRepositorySelection(fact.repository_selection));
+      if (supportedFacts.length > 1) return { account, status: "forbidden" as const, reason: "ambiguous_installation" as const };
+      if (supportedFacts.length === 0) {
+        const invalidScope = exactFacts[0];
+        if (invalidScope) return { account, installationId: invalidScope.installation_id, status: "forbidden" as const, reason: "repository_selection_invalid" as const };
         return { account, status: "pending" as const, reason: "trust_anchor_missing" as const };
       }
-      const fact = selectedFacts[0];
+      const fact = supportedFacts[0];
+      const repositorySelection = githubRepositorySelection(fact.repository_selection)!;
       if (pending.untrusted_installation_id !== fact.installation_id) {
-        return { account, installationId: fact.installation_id, status: "forbidden" as const, reason: "installation_hint_mismatch" as const };
+        return { account, installationId: fact.installation_id, repositorySelection, status: "forbidden" as const, reason: "installation_hint_mismatch" as const };
       }
-      if (fact.state === "suspended") return { account, installationId: fact.installation_id, status: "suspended" as const, reason: "installation_suspended" as const };
+      if (fact.state === "suspended") return { account, installationId: fact.installation_id, repositorySelection, status: "suspended" as const, reason: "installation_suspended" as const };
       if (!hasRequiredInstallationPermissions(fact.permissions_json)) {
-        return { account, installationId: fact.installation_id, status: "forbidden" as const, reason: "permissions_incomplete" as const };
+        return { account, installationId: fact.installation_id, repositorySelection, status: "forbidden" as const, reason: "permissions_incomplete" as const };
       }
-      return { account, installationId: fact.installation_id, status: "pending" as const, reason: "oauth_pending" as const };
+      return { account, installationId: fact.installation_id, repositorySelection, status: "pending" as const, reason: "oauth_pending" as const };
     });
     const status = targets.some((target) => target.status === "connected") ? "connected" as const
       : targets.some((target) => target.status === "suspended") ? "suspended" as const
@@ -761,7 +785,7 @@ export async function handleGithubActor(env: Env, principal: PlexusPrincipal | n
     const policyPayload = actorPolicyPayload(policy);
     const bindings = await getBindings(env, principal!.workspaceId);
     if (bindings.length === 0) return jsonOk({ status: "unconfigured" as const, ...policyPayload });
-    const activeBindings = bindings.filter((binding) => binding.state === "active" && binding.repository_selection === "selected" &&
+    const activeBindings = bindings.filter((binding) => binding.state === "active" && githubRepositorySelection(binding.repository_selection) !== null &&
       isAllowedInstallationTarget(githubInstallationPolicy(env), binding));
     if (activeBindings.length === 0) {
       return jsonOk({ status: "forbidden" as const, ...policyPayload });
@@ -1194,8 +1218,8 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
     } else {
       const existingFact = await queryFirst<{ installation_id: number; state: "active" | "suspended" | "deleted" }>(db, "SELECT installation_id, state FROM github_installation_facts WHERE installation_id = ? LIMIT 1", installationId);
       if (!existingFact) {
-        if (lifecycleAction === "deleted" || repositorySelection !== "selected") {
-          throw new GithubControlPlaneError("github_installation_untrusted", "Installation lifecycle event cannot bootstrap a selected non-deleted trust fact.", 409, true);
+        if (lifecycleAction === "deleted") {
+          throw new GithubControlPlaneError("github_installation_untrusted", "Installation lifecycle event cannot bootstrap a deleted trust fact.", 409, true);
         }
         const initialState = lifecycleAction === "suspend" ? "suspended" : "active";
         await execute(
@@ -1288,60 +1312,137 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
   }
 }
 
+interface GithubBatchDatabase extends ReturnType<typeof database> {
+  batch?(statements: Array<{ run(): Promise<unknown> }>): Promise<unknown[]>;
+}
+
+function prepareGithubMutation(
+  db: ReturnType<typeof database>,
+  sql: string,
+  params: unknown[],
+): { run(): Promise<unknown> } {
+  const statement = db.prepare(sql);
+  return (params.length ? statement.bind(...params) : statement) as unknown as { run(): Promise<unknown> };
+}
+
+async function executeAtomicStatements(
+  db: ReturnType<typeof database>,
+  statements: Array<{ sql: string; params: unknown[] }>,
+): Promise<void> {
+  const batchDb = db as GithubBatchDatabase;
+  if (typeof batchDb.batch === "function") {
+    await batchDb.batch(statements.map(({ sql, params }) => prepareGithubMutation(db, sql, params)));
+    return;
+  }
+  let transactionStarted = false;
+  try {
+    await execute(db, "BEGIN IMMEDIATE TRANSACTION");
+    transactionStarted = true;
+    for (const { sql, params } of statements) await execute(db, sql, ...params);
+    await execute(db, "COMMIT");
+    transactionStarted = false;
+  } catch (error) {
+    if (transactionStarted) {
+      try {
+        await execute(db, "ROLLBACK");
+      } catch {
+        // Best-effort rollback only.
+      }
+    }
+    throw error;
+  }
+}
+
 async function discoverRepositories(env: Env, binding: InstallationBindingRow): Promise<GithubRepository[]> {
   const client = new GithubAppClient(env);
   const token = await client.createInstallationToken(binding.installation_id, null, "discovery");
   const repositories: GithubRepository[] = [];
   let complete = false;
-  for (let page = 1; page <= 100; page += 1) {
-    const response = await client.request<{ repositories: GithubRepository[] }>(token.token, `/installation/repositories?per_page=100&page=${page}`);
+  for (let page = 1; page <= GITHUB_REPOSITORY_PAGE_LIMIT; page += 1) {
+    const response = await client.request<{ repositories: GithubRepository[]; total_count?: number }>(
+      token.token,
+      `/installation/repositories?per_page=${GITHUB_REPOSITORY_PAGE_SIZE}&page=${page}`,
+    );
     repositories.push(...response.repositories);
-    if (response.repositories.length < 100) {
+    const totalCount = response.total_count;
+    const totalCountKnown = typeof totalCount === "number" && Number.isSafeInteger(totalCount) && totalCount >= 0;
+    if ((totalCountKnown && repositories.length >= totalCount) || response.repositories.length < GITHUB_REPOSITORY_PAGE_SIZE) {
       complete = true;
       break;
     }
   }
-  const timestamp = now();
+  if (!complete) {
+    throw new GithubControlPlaneError(
+      "github_repository_discovery_incomplete",
+      "GitHub repository discovery exceeded the safe pagination limit; no partial snapshot was persisted.",
+      502,
+      true,
+    );
+  }
+  const repositoriesById = new Map<number, GithubRepository>();
   for (const repo of repositories) {
     if (!Number.isSafeInteger(repo.id) || repo.id <= 0 || !Number.isSafeInteger(repo.owner?.id) || repo.owner.id <= 0 ||
       !repo.owner.login || !repo.name || !repo.full_name || !repo.default_branch) {
       throw new GithubControlPlaneError("github_repository_identity_invalid", "GitHub returned an invalid numeric repository identity.", 502, true);
     }
+    const previous = repositoriesById.get(repo.id);
+    if (previous && (previous.full_name !== repo.full_name || previous.owner.id !== repo.owner.id || previous.owner.login.toLowerCase() !== repo.owner.login.toLowerCase())) {
+      throw new GithubControlPlaneError("github_repository_identity_conflict", "GitHub returned contradictory metadata for one repository ID.", 502, true);
+    }
+    repositoriesById.set(repo.id, repo);
   }
-  const liveIds = new Set(repositories.filter((repo) => Number.isSafeInteger(repo.id) && repo.id > 0).map((repo) => repo.id));
+  const normalizedRepositories = [...repositoriesById.values()].sort((left, right) => left.id - right.id);
+  const timestamp = now();
+  const liveIds = new Set(normalizedRepositories.map((repo) => repo.id));
   const known = await queryAll<{ repository_id: number }>(
     database(env),
     "SELECT repository_id FROM github_installation_repositories WHERE installation_id = ? AND state = 'active'",
     binding.installation_id,
   );
-  for (const row of complete ? known : []) {
+  const statements: Array<{ sql: string; params: unknown[] }> = [];
+  for (const row of known) {
     if (!liveIds.has(row.repository_id)) {
-      await execute(database(env), "UPDATE github_installation_repositories SET state = 'removed', updated_at = ? WHERE installation_id = ? AND repository_id = ?", timestamp, binding.installation_id, row.repository_id);
+      statements.push({
+        sql: "UPDATE github_installation_repositories SET state = 'removed', updated_at = ? WHERE installation_id = ? AND repository_id = ?",
+        params: [timestamp, binding.installation_id, row.repository_id],
+      });
     }
   }
-  for (const repo of repositories) {
-    if (!Number.isSafeInteger(repo.id) || !repo.owner?.login || !repo.name) continue;
-    await execute(
-      database(env),
-      `INSERT INTO github_installation_repositories
+  for (const repo of normalizedRepositories) {
+    statements.push({
+      sql: `INSERT INTO github_installation_repositories
        (installation_id, repository_id, owner_login, name, full_name, is_private, default_branch, state, observed_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)
        ON CONFLICT(installation_id, repository_id) DO UPDATE SET
          owner_login = excluded.owner_login, name = excluded.name, full_name = excluded.full_name,
          is_private = excluded.is_private, default_branch = excluded.default_branch, state = 'active',
          observed_at = excluded.observed_at, updated_at = excluded.updated_at`,
-      binding.installation_id,
-      repo.id,
-      repo.owner.login,
-      repo.name,
-      repo.full_name,
-      repo.private ? 1 : 0,
-      repo.default_branch,
-      timestamp,
-      timestamp,
-    );
+      params: [
+        binding.installation_id,
+        repo.id,
+        repo.owner.login,
+        repo.name,
+        repo.full_name,
+        repo.private ? 1 : 0,
+        repo.default_branch,
+        timestamp,
+        timestamp,
+      ],
+    });
   }
-  return repositories;
+  if (statements.length > 0) {
+    try {
+      await executeAtomicStatements(database(env), statements);
+    } catch {
+      throw new GithubControlPlaneError(
+        "github_repository_snapshot_failed",
+        "The repository snapshot could not be committed atomically; the previous authority remains in place.",
+        503,
+        true,
+      );
+    }
+  }
+  return normalizedRepositories;
 }
 
 export async function handleGithubRepositories(env: Env, principal: PlexusPrincipal | null): Promise<Response> {
@@ -1349,8 +1450,14 @@ export async function handleGithubRepositories(env: Env, principal: PlexusPrinci
   if (denied) return denied;
   try {
     const bindings = await assertActiveBindings(env, principal!.workspaceId);
-    const repositories = (await Promise.all(bindings.map(async (binding) => ({ binding, repositories: await discoverRepositories(env, binding) }))))
+    const discovered = (await Promise.all(bindings.map(async (binding) => ({ binding, repositories: await discoverRepositories(env, binding) }))))
       .flatMap(({ binding, repositories: installationRepositories }) => installationRepositories.map((repo) => ({ binding, repo })));
+    const repositories = [...new Map(discovered.map((entry) => [entry.repo.id, entry])).values()]
+      .sort((left, right) => {
+        const leftName = left.repo.full_name.toLowerCase();
+        const rightName = right.repo.full_name.toLowerCase();
+        return leftName < rightName ? -1 : leftName > rightName ? 1 : left.repo.id - right.repo.id;
+      });
     return jsonOk({
       status: "connected" as const,
       repositories: repositories.map(({ binding, repo }) => ({
@@ -1361,6 +1468,7 @@ export async function handleGithubRepositories(env: Env, principal: PlexusPrinci
         defaultBranch: repo.default_branch,
         owner: repo.owner.login,
         installationId: binding.installation_id,
+        repositorySelection: githubRepositorySelection(binding.repository_selection),
         account: installationTargetOf(binding),
       })),
     });
@@ -1439,6 +1547,7 @@ export async function handleGithubRepoVerify(env: Env, request: Request, project
         defaultBranch: repo.default_branch,
         verifiedAt,
         installationId: binding.installation_id,
+        repositorySelection: githubRepositorySelection(binding.repository_selection),
         account: installationTargetOf(binding),
       },
     });

--- a/cloudflare/worker/src/routes/github.ts
+++ b/cloudflare/worker/src/routes/github.ts
@@ -1198,6 +1198,10 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
     const observedAt = now();
     let resultReason = "fact_updated";
     if (eventName === "installation" && lifecycleAction === "created") {
+      const existingCreatedFact = await queryFirst<{ state: "active" | "suspended" | "deleted" }>(db, "SELECT state FROM github_installation_facts WHERE installation_id = ? LIMIT 1", installationId);
+      if (existingCreatedFact?.state === "deleted") {
+        throw new GithubControlPlaneError("github_installation_revoked", "A deleted GitHub installation cannot be resurrected by a later lifecycle event.", 409, true);
+      }
       await execute(
         db,
         `INSERT INTO github_installation_facts
@@ -1250,6 +1254,7 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
     const installationDeleted = eventName === "installation" && lifecycleAction === "deleted";
     if (installationDeleted) {
       await execute(db, "UPDATE github_installation_repositories SET state = 'removed', updated_at = ? WHERE installation_id = ?", observedAt, installationId);
+      await execute(db, "DELETE FROM project_github_verifications WHERE installation_id = ?", installationId);
     } else {
       const repositoryFactState = await queryFirst<{ state: string }>(db, "SELECT state FROM github_installation_facts WHERE installation_id = ? LIMIT 1", installationId);
       const repositoryState = repositoryFactState?.state === "active" ? "active" : "removed";
@@ -1282,6 +1287,7 @@ export async function handleGithubWebhook(env: Env, request: Request): Promise<R
         const repo = webhookRepository(value, accountTarget);
         if (!repo) throw new GithubControlPlaneError("github_webhook_repository_invalid", "Signed webhook contains an invalid removed repository fact.", 400);
         await execute(db, "UPDATE github_installation_repositories SET state = 'removed', updated_at = ? WHERE installation_id = ? AND repository_id = ?", observedAt, installationId, repo.id);
+        await execute(db, "DELETE FROM project_github_verifications WHERE installation_id = ? AND repository_id = ?", installationId, repo.id);
       }
     }
     const storedFact = await queryFirst<{ installer_sender_id: number; state: string }>(db, "SELECT installer_sender_id, state FROM github_installation_facts WHERE installation_id = ? LIMIT 1", installationId);
@@ -1357,18 +1363,41 @@ async function discoverRepositories(env: Env, binding: InstallationBindingRow): 
   const client = new GithubAppClient(env);
   const token = await client.createInstallationToken(binding.installation_id, null, "discovery");
   const repositories: GithubRepository[] = [];
+  const discoveredIds = new Set<number>();
+  let expectedTotalCount: number | null = null;
   let complete = false;
   for (let page = 1; page <= GITHUB_REPOSITORY_PAGE_LIMIT; page += 1) {
     const response = await client.request<{ repositories: GithubRepository[]; total_count?: number }>(
       token.token,
       `/installation/repositories?per_page=${GITHUB_REPOSITORY_PAGE_SIZE}&page=${page}`,
     );
-    repositories.push(...response.repositories);
+    if (!response || !Array.isArray(response.repositories)) {
+      throw new GithubControlPlaneError("github_repository_discovery_payload_invalid", "GitHub returned an invalid repository discovery payload.", 502, true);
+    }
     const totalCount = response.total_count;
     const totalCountKnown = typeof totalCount === "number" && Number.isSafeInteger(totalCount) && totalCount >= 0;
-    if ((totalCountKnown && repositories.length >= totalCount) || response.repositories.length < GITHUB_REPOSITORY_PAGE_SIZE) {
+    if (response.total_count !== undefined && !totalCountKnown) {
+      throw new GithubControlPlaneError("github_repository_discovery_payload_invalid", "GitHub returned an invalid repository total count.", 502, true);
+    }
+    if (totalCountKnown) {
+      if (expectedTotalCount !== null && expectedTotalCount !== totalCount) {
+        throw new GithubControlPlaneError("github_repository_discovery_inconsistent", "GitHub repository pagination returned inconsistent totals.", 502, true);
+      }
+      expectedTotalCount = totalCount;
+    }
+    repositories.push(...response.repositories);
+    for (const repository of response.repositories) {
+      if (Number.isSafeInteger(repository?.id) && repository.id > 0) discoveredIds.add(repository.id);
+    }
+    if (totalCountKnown && discoveredIds.size > totalCount) {
+      throw new GithubControlPlaneError("github_repository_discovery_inconsistent", "GitHub repository pagination returned more unique repositories than its total count.", 502, true);
+    }
+    if ((totalCountKnown && discoveredIds.size >= totalCount) || (!totalCountKnown && response.repositories.length < GITHUB_REPOSITORY_PAGE_SIZE)) {
       complete = true;
       break;
+    }
+    if (response.repositories.length < GITHUB_REPOSITORY_PAGE_SIZE) {
+      throw new GithubControlPlaneError("github_repository_discovery_incomplete", "GitHub repository pagination ended before the advertised complete inventory was received.", 502, true);
     }
   }
   if (!complete) {
@@ -1381,9 +1410,15 @@ async function discoverRepositories(env: Env, binding: InstallationBindingRow): 
   }
   const repositoriesById = new Map<number, GithubRepository>();
   for (const repo of repositories) {
-    if (!Number.isSafeInteger(repo.id) || repo.id <= 0 || !Number.isSafeInteger(repo.owner?.id) || repo.owner.id <= 0 ||
+    if (!repo || !Number.isSafeInteger(repo.id) || repo.id <= 0 || !Number.isSafeInteger(repo.owner?.id) || repo.owner.id <= 0 ||
       !repo.owner.login || !repo.name || !repo.full_name || !repo.default_branch) {
       throw new GithubControlPlaneError("github_repository_identity_invalid", "GitHub returned an invalid numeric repository identity.", 502, true);
+    }
+    const fullNameParts = repo.full_name.split("/");
+    if (repo.owner.id !== binding.account_id || repo.owner.login.toLowerCase() !== binding.account_login.toLowerCase() ||
+      fullNameParts.length !== 2 || fullNameParts[0].toLowerCase() !== repo.owner.login.toLowerCase() ||
+      fullNameParts[1].toLowerCase() !== repo.name.toLowerCase()) {
+      throw new GithubControlPlaneError("github_repository_account_mismatch", "GitHub returned a repository outside the installation account authority.", 502, true);
     }
     const previous = repositoriesById.get(repo.id);
     if (previous && (previous.full_name !== repo.full_name || previous.owner.id !== repo.owner.id || previous.owner.login.toLowerCase() !== repo.owner.login.toLowerCase())) {
@@ -1403,8 +1438,12 @@ async function discoverRepositories(env: Env, binding: InstallationBindingRow): 
   for (const row of known) {
     if (!liveIds.has(row.repository_id)) {
       statements.push({
-        sql: "UPDATE github_installation_repositories SET state = 'removed', updated_at = ? WHERE installation_id = ? AND repository_id = ?",
-        params: [timestamp, binding.installation_id, row.repository_id],
+        sql: "UPDATE github_installation_repositories SET state = 'removed', updated_at = ? WHERE installation_id = ? AND repository_id = ? AND updated_at <= ?",
+        params: [timestamp, binding.installation_id, row.repository_id, timestamp],
+      });
+      statements.push({
+        sql: "DELETE FROM project_github_verifications WHERE installation_id = ? AND repository_id = ?",
+        params: [binding.installation_id, row.repository_id],
       });
     }
   }
@@ -1416,7 +1455,8 @@ async function discoverRepositories(env: Env, binding: InstallationBindingRow): 
        ON CONFLICT(installation_id, repository_id) DO UPDATE SET
          owner_login = excluded.owner_login, name = excluded.name, full_name = excluded.full_name,
          is_private = excluded.is_private, default_branch = excluded.default_branch, state = 'active',
-         observed_at = excluded.observed_at, updated_at = excluded.updated_at`,
+         observed_at = excluded.observed_at, updated_at = excluded.updated_at
+       WHERE excluded.observed_at >= github_installation_repositories.observed_at`,
       params: [
         binding.installation_id,
         repo.id,
@@ -1513,6 +1553,10 @@ export async function handleGithubRepoVerify(env: Env, request: Request, project
     const token = await client.createInstallationToken(binding.installation_id, [repositoryId], "metadata");
     const repo = await client.request<GithubRepository>(token.token, `/repos/${encodeURIComponent(authority.owner_login)}/${encodeURIComponent(authority.name)}`);
     if (repo.id !== repositoryId) throw new GithubControlPlaneError("github_repository_identity_mismatch", "GitHub repository identity did not match the requested numeric ID.", 409);
+    if (repo.owner.id !== binding.account_id || repo.owner.login.toLowerCase() !== binding.account_login.toLowerCase() ||
+      repo.name.toLowerCase() !== authority.name.toLowerCase() || repo.full_name.toLowerCase() !== authority.full_name.toLowerCase()) {
+      throw new GithubControlPlaneError("github_repository_metadata_mismatch", "GitHub repository metadata did not match the authorized repository binding.", 409);
+    }
     const verifiedAt = now();
     await execute(
       database(env),
@@ -1563,7 +1607,9 @@ async function getVerifiedRepository(env: Env, projectId: string, workspaceId: s
        FROM project_github_verifications v
        JOIN github_installation_repositories r
          ON r.installation_id = v.installation_id AND r.repository_id = v.repository_id
-      WHERE v.project_id = ? AND v.workspace_id = ? AND r.state = 'active' LIMIT 1`,
+      WHERE v.project_id = ? AND v.workspace_id = ? AND r.state = 'active'
+        AND v.repo_owner = r.owner_login AND v.repo_name = r.name AND v.default_branch = r.default_branch
+      LIMIT 1`,
     projectId,
     workspaceId,
   );

--- a/cloudflare/worker/src/routes/github.ts
+++ b/cloudflare/worker/src/routes/github.ts
@@ -922,9 +922,50 @@ async function handleGithubActorCallback(
   }
 }
 
+async function handleStatelessGithubInstallationCallback(env: Env, request: Request, url: URL): Promise<Response> {
+  const installationParam = url.searchParams.get("installation_id");
+  const setupAction = url.searchParams.get("setup_action");
+  const installationId = installationParam && /^\d+$/.test(installationParam) ? Number(installationParam) : null;
+  if (!installationId || !Number.isSafeInteger(installationId)) {
+    throw new GithubControlPlaneError("github_installation_hint_invalid", "Installation ID hint must be numeric.", 400);
+  }
+  if (setupAction !== "install" && setupAction !== "update") {
+    throw new GithubControlPlaneError("github_callback_invalid", "GitHub installation setup action is invalid.", 400);
+  }
+
+  const fact = await queryFirst<InstallationFactRow>(
+    database(env),
+    "SELECT installation_id, installer_sender_id, account_id, account_login, account_type, repository_selection, permissions_json, state FROM github_installation_facts WHERE installation_id = ? LIMIT 1",
+    installationId,
+  );
+  if (!fact || fact.state === "deleted") {
+    throw new GithubControlPlaneError(
+      "github_installation_fact_pending",
+      "The signed GitHub installation event has not been verified yet. Return to Plexus and refresh.",
+      409,
+      true,
+    );
+  }
+  if (fact.account_type !== "Organization" && fact.account_type !== "User") {
+    throw new GithubControlPlaneError("github_installation_account_forbidden", "GitHub App installation account type is invalid.", 403);
+  }
+  if (!githubRepositorySelection(fact.repository_selection)) {
+    throw new GithubControlPlaneError("github_repository_selection_forbidden", "GitHub App repository selection is unsupported.", 403);
+  }
+
+  const target = { id: fact.account_id, login: fact.account_login, type: fact.account_type };
+  return githubCallbackCompletion(request, plexusGithubInstallationReturnUrl(env, target), {
+    status: "pending" as const,
+    target,
+  });
+}
+
 export async function handleGithubCallback(env: Env, request: Request, url: URL): Promise<Response> {
   try {
     const stateValue = url.searchParams.get("state") ?? "";
+    if (!stateValue && (url.searchParams.has("installation_id") || url.searchParams.has("setup_action"))) {
+      return await handleStatelessGithubInstallationCallback(env, request, url);
+    }
     const state = await verifyConnectState(stateValue, stateSecret(env));
     await ensureCallbackActorStillAdmin(env, state);
     const nonceHash = await sha256Hex(state.nonce);

--- a/cloudflare/worker/wrangler.jsonc
+++ b/cloudflare/worker/wrangler.jsonc
@@ -27,7 +27,7 @@
     // Server-owned scope for GET /v1/reporting/weekly-context. The dedicated
     // TF_REPORTING_READ_TOKEN must be configured with `wrangler secret put`.
     // "TF_REPORTING_WORKSPACE_ID": "replace-with-workspace-id",
-    "TF_INTEGRATION_CONFIG_JSON": "{\"github\":{\"repos\":[{\"repo\":\"Sheshiyer/parkarea-aleph\",\"displayName\":\"ParkArea Phase 2 - Germany Launch\",\"clientName\":\"ParkArea\",\"defaultMilestoneNumber\":1,\"enabled\":true}]},\"huly\":{\"mirrorMode\":\"read_only\",\"mirrorEnabled\":true},\"slack\":{},\"clockify\":{}}",
+    "TF_INTEGRATION_CONFIG_JSON": "{\"github\":{\"repos\":[]},\"huly\":{\"mirrorMode\":\"read_only\",\"mirrorEnabled\":true},\"slack\":{},\"clockify\":{}}",
     // Temporary internal shared secret for m2m (parity, Hermes) bypassing CF Access service token issues on this Worker route.
     // Set a long random value. Callers send header X-TeamForge-Internal-Secret.
     // "TF_INTERNAL_SHARED_SECRET": "replace-with-long-random-secret"


### PR DESCRIPTION
## Summary
- accept GitHub App installations configured for selected or all repositories
- paginate all-repository discovery without persisting stale authority
- recover state-less GitHub settings callbacks only from signed installation facts

## Security
- exact pinned owner and founder identities remain enforced
- callback query parameters never create or mutate workspace authority
- unknown or ambiguous installation state remains fail-closed
- no migration, secret, or direct D1 row mutation

## Verification
- 175 Worker tests pass
- Worker typecheck passes
- retired-routing guard passes
- production migration preflight reports no pending migrations

## Rollout
After protected merge and exact-main CI, deploy the merge commit with Wrangler, verify /healthz, then save and re-check each owner installation before any Plexus OTA tag.