### PR TITLE
feat(worker): add queue lifecycle receipts

### DIFF
--- a/cloudflare/worker/README.md
+++ b/cloudflare/worker/README.md
@@ -117,11 +117,20 @@ explicitly gated remote operations.
 frozen `teamforge.sync-job.v1` envelope. Queue payloads, vendor response bodies,
 and tokens are never stored; D1 retains only job/run state, fixed bounded
 failure evidence, and `teamforge.sync-runtime-receipt.v1` liveness evidence.
+Missing bindings or rejected sends terminalize the producer job with fixed
+failure evidence and return 503 instead of leaving queued work orphaned.
+
+The existing `/v1/team/refresh` route still produces the bounded legacy
+`team_snapshot` shape. The Queue consumer does not pretend this unsupported job
+executed: an exact matching legacy job is terminalized as failed with fixed
+`job_type_unsupported` run evidence, a rejected runtime receipt, and no vendor
+adapter call. Malformed legacy shapes are acknowledged before D1 access.
 
 Bootstrap reports consumer evidence independently of route presence:
 
 - missing Queue binding: `unavailable`
 - bound without a runtime receipt: `degraded` / `consumer_receipt_missing`
+- malformed or materially future receipt: `degraded` / `consumer_receipt_invalid`
 - expired receipt: `stale` / `consumer_receipt_stale`
 - fresh completed receipt: `healthy`
 - fresh failed receipt: `degraded` / `last_consumer_failed`
@@ -135,7 +144,8 @@ The digest covers the exact unmodified Markdown UTF-8 bytes, capped at 32 KiB.
 
 Network delivery is disabled unless `--apply`, `--projection-url-env <name>`,
 and `--projection-token-env <name>` are all supplied and the two named
-environment variables are set. The bearer value is never printed.
+environment variables are set. Apply endpoints must use HTTPS. The bearer
+value is never printed.
 
 ## Next Steps
 

--- a/cloudflare/worker/README.md
+++ b/cloudflare/worker/README.md
@@ -102,6 +102,40 @@ Because of that, `wrangler.jsonc` still contains placeholder IDs for:
 - D1 database name: `teamforge-primary`
 - R2 bucket name: `teamforge-artifacts`
 - Queue name: `teamforge-sync`
+- Queue dead-letter name: `teamforge-sync-dlq`
+
+## Project sync Queue contract
+
+The Worker source declares, but does not create, a `teamforge-sync` consumer
+with a maximum batch size of 5, five-second batch timeout, three retries, and
+the `teamforge-sync-dlq` dead-letter target. Provisioning either Queue,
+applying `0017_sync_runtime_receipts.sql`, and deploying the Worker remain
+explicitly gated remote operations.
+
+`POST /v1/sync/jobs` accepts a bounded `workspace_id`, `project_id`, one of
+`clockify|github|huly|slack`, and only the `project_sync` job type. It emits the
+frozen `teamforge.sync-job.v1` envelope. Queue payloads, vendor response bodies,
+and tokens are never stored; D1 retains only job/run state, fixed bounded
+failure evidence, and `teamforge.sync-runtime-receipt.v1` liveness evidence.
+
+Bootstrap reports consumer evidence independently of route presence:
+
+- missing Queue binding: `unavailable`
+- bound without a runtime receipt: `degraded` / `consumer_receipt_missing`
+- expired receipt: `stale` / `consumer_receipt_stale`
+- fresh completed receipt: `healthy`
+- fresh failed receipt: `degraded` / `last_consumer_failed`
+
+## Daily standup context projection
+
+`scripts/teamforge-vault-parity.mjs --context-projection <markdown-path>` builds
+the frozen `thoughtseed.context-projection.v1` projection in dry-run mode.
+Default output is metadata-only: key, digest, generation, and timestamps.
+The digest covers the exact unmodified Markdown UTF-8 bytes, capped at 32 KiB.
+
+Network delivery is disabled unless `--apply`, `--projection-url-env <name>`,
+and `--projection-token-env <name>` are all supplied and the two named
+environment variables are set. The bearer value is never printed.
 
 ## Next Steps
 
@@ -112,7 +146,7 @@ Because of that, `wrangler.jsonc` still contains placeholder IDs for:
    - Huly project links
    - project artifacts
    - project sync policy
-3. Create the R2 bucket and queue, then replace the remaining placeholders if still missing.
+3. Create the R2 bucket, Queue, and DLQ, then replace remaining placeholders if still missing.
 4. Implement the first repository-backed project routes:
    - `/v1/projects` for summary rows
    - `/v1/project-mappings` for full project graph reads/writes

--- a/cloudflare/worker/migrations/0017_sync_runtime_receipts.sql
+++ b/cloudflare/worker/migrations/0017_sync_runtime_receipts.sql
@@ -6,10 +6,10 @@ CREATE INDEX idx_sync_jobs_project_status
   ON sync_jobs(project_id, status, created_at);
 
 CREATE TABLE sync_runtime_receipts (
-  runtime_id TEXT PRIMARY KEY,
+  runtime_id TEXT NOT NULL PRIMARY KEY,
   schema_version TEXT NOT NULL CHECK (schema_version = 'teamforge.sync-runtime-receipt.v1'),
-  last_message_id TEXT,
-  last_job_id TEXT,
+  last_message_id TEXT NOT NULL,
+  last_job_id TEXT NOT NULL,
   last_status TEXT NOT NULL CHECK (last_status IN ('completed', 'failed', 'rejected')),
   last_consumed_at TEXT NOT NULL,
   last_terminal_at TEXT NOT NULL,

--- a/cloudflare/worker/migrations/0017_sync_runtime_receipts.sql
+++ b/cloudflare/worker/migrations/0017_sync_runtime_receipts.sql
@@ -1,0 +1,20 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE sync_jobs ADD COLUMN project_id TEXT REFERENCES projects(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_sync_jobs_project_status
+  ON sync_jobs(project_id, status, created_at);
+
+CREATE TABLE sync_runtime_receipts (
+  runtime_id TEXT PRIMARY KEY,
+  schema_version TEXT NOT NULL CHECK (schema_version = 'teamforge.sync-runtime-receipt.v1'),
+  last_message_id TEXT,
+  last_job_id TEXT,
+  last_status TEXT NOT NULL CHECK (last_status IN ('completed', 'failed', 'rejected')),
+  last_consumed_at TEXT NOT NULL,
+  last_terminal_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_sync_runtime_receipts_updated
+  ON sync_runtime_receipts(updated_at DESC);

--- a/cloudflare/worker/src/index.ts
+++ b/cloudflare/worker/src/index.ts
@@ -1,6 +1,7 @@
-import type { DurableObjectStateLike, Env } from "./lib/env";
+import type { DurableObjectStateLike, Env, QueueBatchLike } from "./lib/env";
 import { requireBearerAuth } from "./lib/auth";
 import { jsonError, jsonOk } from "./lib/response";
+import { handleSyncQueueBatch } from "./lib/sync-queue";
 import { handleInternalRequest } from "./routes/internal";
 import { handleV1Request } from "./routes/v1";
 
@@ -55,6 +56,9 @@ export default {
       },
       404,
     );
+  },
+  async queue(batch: QueueBatchLike<unknown>, env: Env): Promise<void> {
+    await handleSyncQueueBatch(batch, env);
   },
 };
 

--- a/cloudflare/worker/src/lib/control-plane-status.test.ts
+++ b/cloudflare/worker/src/lib/control-plane-status.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { D1DatabaseLike, Env } from "./env";
+import { getSyncConsumerStatus } from "./control-plane-status";
+import worker from "../index";
+
+function dbWithReceipt(receipt: Record<string, unknown> | null): D1DatabaseLike {
+  return {
+    prepare() {
+      return {
+        bind() {
+          return this;
+        },
+        async first<T>() {
+          return receipt as T | null;
+        },
+        async run() {
+          return { success: true };
+        },
+        async all<T>() {
+          return { results: [] as T[] };
+        },
+      };
+    },
+  };
+}
+
+function boundEnv(receipt: Record<string, unknown> | null): Env {
+  return {
+    TF_ENV: "test",
+    TEAMFORGE_DB: dbWithReceipt(receipt),
+    SYNC_QUEUE: { async send() {} },
+  };
+}
+
+const now = new Date("2026-07-28T10:00:00.000Z");
+
+describe("sync consumer control-plane status", () => {
+  it("reports a missing Queue binding as unavailable", async () => {
+    expect(await getSyncConsumerStatus({ TF_ENV: "test" }, now)).toMatchObject({
+      status: "unavailable",
+      reason: "consumer_binding_missing",
+    });
+  });
+
+  it("reports a bound consumer without a receipt as degraded", async () => {
+    expect(await getSyncConsumerStatus(boundEnv(null), now)).toMatchObject({
+      status: "degraded",
+      reason: "consumer_receipt_missing",
+    });
+  });
+
+  it("reports an expired receipt as stale", async () => {
+    expect(await getSyncConsumerStatus(boundEnv({
+      runtime_id: "runtime_1",
+      last_status: "completed",
+      updated_at: "2026-07-28T09:00:00.000Z",
+    }), now)).toMatchObject({
+      status: "stale",
+      reason: "consumer_receipt_stale",
+    });
+  });
+
+  it("reports a fresh completed receipt as healthy", async () => {
+    expect(await getSyncConsumerStatus(boundEnv({
+      runtime_id: "runtime_1",
+      last_status: "completed",
+      updated_at: "2026-07-28T09:59:00.000Z",
+    }), now)).toMatchObject({
+      status: "healthy",
+      reason: null,
+    });
+  });
+
+  it("reports a fresh failed receipt as degraded", async () => {
+    expect(await getSyncConsumerStatus(boundEnv({
+      runtime_id: "runtime_1",
+      last_status: "failed",
+      updated_at: "2026-07-28T09:59:00.000Z",
+    }), now)).toMatchObject({
+      status: "degraded",
+      reason: "last_consumer_failed",
+    });
+  });
+
+  it("does not let live route presence override missing consumer evidence", async () => {
+    const response = await worker.fetch(
+      new Request("https://forge.example/v1/bootstrap"),
+      { TF_ENV: "test" },
+    );
+    const payload = await response.json() as {
+      data: {
+        routeStatus: { sync: string };
+        controlPlaneStatus: { syncConsumer: { status: string } };
+      };
+    };
+
+    expect(payload.data.routeStatus.sync).toBe("live");
+    expect(payload.data.controlPlaneStatus.syncConsumer.status).toBe("unavailable");
+  });
+});

--- a/cloudflare/worker/src/lib/control-plane-status.test.ts
+++ b/cloudflare/worker/src/lib/control-plane-status.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
 import type { D1DatabaseLike, Env } from "./env";
 import { getSyncConsumerStatus } from "./control-plane-status";
 import worker from "../index";
@@ -33,6 +34,16 @@ function boundEnv(receipt: Record<string, unknown> | null): Env {
 }
 
 const now = new Date("2026-07-28T10:00:00.000Z");
+const validReceipt = {
+  schema_version: "teamforge.sync-runtime-receipt.v1",
+  runtime_id: "runtime_1",
+  last_message_id: "message_1",
+  last_job_id: "job_1",
+  last_status: "completed",
+  last_consumed_at: "2026-07-28T09:59:00.000Z",
+  last_terminal_at: "2026-07-28T09:59:00.000Z",
+  updated_at: "2026-07-28T09:59:00.000Z",
+};
 
 describe("sync consumer control-plane status", () => {
   it("reports a missing Queue binding as unavailable", async () => {
@@ -51,8 +62,9 @@ describe("sync consumer control-plane status", () => {
 
   it("reports an expired receipt as stale", async () => {
     expect(await getSyncConsumerStatus(boundEnv({
-      runtime_id: "runtime_1",
-      last_status: "completed",
+      ...validReceipt,
+      last_consumed_at: "2026-07-28T09:00:00.000Z",
+      last_terminal_at: "2026-07-28T09:00:00.000Z",
       updated_at: "2026-07-28T09:00:00.000Z",
     }), now)).toMatchObject({
       status: "stale",
@@ -62,9 +74,7 @@ describe("sync consumer control-plane status", () => {
 
   it("reports a fresh completed receipt as healthy", async () => {
     expect(await getSyncConsumerStatus(boundEnv({
-      runtime_id: "runtime_1",
-      last_status: "completed",
-      updated_at: "2026-07-28T09:59:00.000Z",
+      ...validReceipt,
     }), now)).toMatchObject({
       status: "healthy",
       reason: null,
@@ -73,13 +83,49 @@ describe("sync consumer control-plane status", () => {
 
   it("reports a fresh failed receipt as degraded", async () => {
     expect(await getSyncConsumerStatus(boundEnv({
-      runtime_id: "runtime_1",
+      ...validReceipt,
       last_status: "failed",
-      updated_at: "2026-07-28T09:59:00.000Z",
     }), now)).toMatchObject({
       status: "degraded",
       reason: "last_consumer_failed",
     });
+  });
+
+  it("does not report malformed fresh receipt evidence as healthy", async () => {
+    expect(await getSyncConsumerStatus(boundEnv({
+      ...validReceipt,
+      schema_version: "unknown.receipt.v1",
+      runtime_id: null,
+      last_message_id: null,
+      last_job_id: null,
+      last_consumed_at: null,
+      last_terminal_at: null,
+    }), now)).toMatchObject({
+      status: "degraded",
+      reason: "consumer_receipt_invalid",
+    });
+  });
+
+  it("does not report materially future receipt evidence as healthy", async () => {
+    expect(await getSyncConsumerStatus(boundEnv({
+      ...validReceipt,
+      last_consumed_at: "2026-07-28T10:30:00.000Z",
+      last_terminal_at: "2026-07-28T10:30:00.000Z",
+      updated_at: "2026-07-28T10:30:00.000Z",
+    }), now)).toMatchObject({
+      status: "degraded",
+      reason: "consumer_receipt_invalid",
+    });
+  });
+
+  it("requires all persisted receipt identifiers to be non-null", () => {
+    const migration = readFileSync(
+      new URL("../../migrations/0017_sync_runtime_receipts.sql", import.meta.url),
+      "utf8",
+    );
+    expect(migration).toMatch(/runtime_id TEXT NOT NULL PRIMARY KEY/);
+    expect(migration).toMatch(/last_message_id TEXT NOT NULL/);
+    expect(migration).toMatch(/last_job_id TEXT NOT NULL/);
   });
 
   it("does not let live route presence override missing consumer evidence", async () => {

--- a/cloudflare/worker/src/lib/control-plane-status.ts
+++ b/cloudflare/worker/src/lib/control-plane-status.ts
@@ -1,13 +1,15 @@
 import type { Env } from "./env";
 
 export const SYNC_CONSUMER_RECEIPT_MAX_AGE_MS = 15 * 60 * 1_000;
+export const SYNC_CONSUMER_RECEIPT_MAX_FUTURE_SKEW_MS = 5 * 60 * 1_000;
 
 type ConsumerStatus = "unavailable" | "degraded" | "stale" | "healthy";
 
 interface RuntimeReceiptRow {
+  schema_version: string;
   runtime_id: string;
-  last_message_id: string | null;
-  last_job_id: string | null;
+  last_message_id: string;
+  last_job_id: string;
   last_status: "completed" | "failed" | "rejected";
   last_consumed_at: string;
   last_terminal_at: string;
@@ -19,6 +21,7 @@ export interface SyncConsumerStatus {
   reason:
     | "consumer_binding_missing"
     | "consumer_receipt_missing"
+    | "consumer_receipt_invalid"
     | "consumer_receipt_stale"
     | "last_consumer_failed"
     | "last_consumer_rejected"
@@ -46,6 +49,54 @@ function status(
   };
 }
 
+function isBoundedIdentity(value: unknown): value is string {
+  return typeof value === "string"
+    && value.trim().length > 0
+    && value.trim() === value
+    && new TextEncoder().encode(value).byteLength <= 256;
+}
+
+function parseCanonicalTimestamp(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const timestamp = Date.parse(value);
+  if (
+    !Number.isFinite(timestamp)
+    || new Date(timestamp).toISOString() !== value
+  ) {
+    return null;
+  }
+  return timestamp;
+}
+
+function validateReceipt(
+  receipt: RuntimeReceiptRow,
+  at: Date,
+): { valid: true; updatedAt: number } | { valid: false } {
+  if (
+    receipt.schema_version !== "teamforge.sync-runtime-receipt.v1"
+    || !isBoundedIdentity(receipt.runtime_id)
+    || !isBoundedIdentity(receipt.last_message_id)
+    || !isBoundedIdentity(receipt.last_job_id)
+    || !["completed", "failed", "rejected"].includes(receipt.last_status)
+  ) {
+    return { valid: false };
+  }
+  const consumedAt = parseCanonicalTimestamp(receipt.last_consumed_at);
+  const terminalAt = parseCanonicalTimestamp(receipt.last_terminal_at);
+  const updatedAt = parseCanonicalTimestamp(receipt.updated_at);
+  if (
+    consumedAt === null
+    || terminalAt === null
+    || updatedAt === null
+    || consumedAt > terminalAt
+    || terminalAt > updatedAt
+    || updatedAt > at.getTime() + SYNC_CONSUMER_RECEIPT_MAX_FUTURE_SKEW_MS
+  ) {
+    return { valid: false };
+  }
+  return { valid: true, updatedAt };
+}
+
 export async function getSyncConsumerStatus(
   env: Env,
   at: Date = new Date(),
@@ -60,7 +111,7 @@ export async function getSyncConsumerStatus(
   let receipt: RuntimeReceiptRow | null;
   try {
     receipt = await env.TEAMFORGE_DB.prepare(
-      `SELECT runtime_id, last_message_id, last_job_id, last_status,
+      `SELECT schema_version, runtime_id, last_message_id, last_job_id, last_status,
               last_consumed_at, last_terminal_at, updated_at
        FROM sync_runtime_receipts
        ORDER BY updated_at DESC
@@ -73,10 +124,13 @@ export async function getSyncConsumerStatus(
     return status("degraded", "consumer_receipt_missing");
   }
 
-  const updatedAt = Date.parse(receipt.updated_at);
+  const validation = validateReceipt(receipt, at);
+  if (!validation.valid) {
+    return status("degraded", "consumer_receipt_invalid", receipt);
+  }
+  const { updatedAt } = validation;
   if (
-    !Number.isFinite(updatedAt)
-    || at.getTime() - updatedAt > SYNC_CONSUMER_RECEIPT_MAX_AGE_MS
+    at.getTime() - updatedAt > SYNC_CONSUMER_RECEIPT_MAX_AGE_MS
   ) {
     return status("stale", "consumer_receipt_stale", receipt);
   }

--- a/cloudflare/worker/src/lib/control-plane-status.ts
+++ b/cloudflare/worker/src/lib/control-plane-status.ts
@@ -1,0 +1,90 @@
+import type { Env } from "./env";
+
+export const SYNC_CONSUMER_RECEIPT_MAX_AGE_MS = 15 * 60 * 1_000;
+
+type ConsumerStatus = "unavailable" | "degraded" | "stale" | "healthy";
+
+interface RuntimeReceiptRow {
+  runtime_id: string;
+  last_message_id: string | null;
+  last_job_id: string | null;
+  last_status: "completed" | "failed" | "rejected";
+  last_consumed_at: string;
+  last_terminal_at: string;
+  updated_at: string;
+}
+
+export interface SyncConsumerStatus {
+  status: ConsumerStatus;
+  reason:
+    | "consumer_binding_missing"
+    | "consumer_receipt_missing"
+    | "consumer_receipt_stale"
+    | "last_consumer_failed"
+    | "last_consumer_rejected"
+    | null;
+  runtimeId: string | null;
+  lastStatus: RuntimeReceiptRow["last_status"] | null;
+  lastConsumedAt: string | null;
+  lastTerminalAt: string | null;
+  updatedAt: string | null;
+}
+
+function status(
+  value: ConsumerStatus,
+  reason: SyncConsumerStatus["reason"],
+  receipt: RuntimeReceiptRow | null = null,
+): SyncConsumerStatus {
+  return {
+    status: value,
+    reason,
+    runtimeId: receipt?.runtime_id ?? null,
+    lastStatus: receipt?.last_status ?? null,
+    lastConsumedAt: receipt?.last_consumed_at ?? null,
+    lastTerminalAt: receipt?.last_terminal_at ?? null,
+    updatedAt: receipt?.updated_at ?? null,
+  };
+}
+
+export async function getSyncConsumerStatus(
+  env: Env,
+  at: Date = new Date(),
+): Promise<SyncConsumerStatus> {
+  if (!env.SYNC_QUEUE) {
+    return status("unavailable", "consumer_binding_missing");
+  }
+  if (!env.TEAMFORGE_DB) {
+    return status("degraded", "consumer_receipt_missing");
+  }
+
+  let receipt: RuntimeReceiptRow | null;
+  try {
+    receipt = await env.TEAMFORGE_DB.prepare(
+      `SELECT runtime_id, last_message_id, last_job_id, last_status,
+              last_consumed_at, last_terminal_at, updated_at
+       FROM sync_runtime_receipts
+       ORDER BY updated_at DESC
+       LIMIT 1`,
+    ).bind().first<RuntimeReceiptRow>();
+  } catch {
+    return status("degraded", "consumer_receipt_missing");
+  }
+  if (!receipt) {
+    return status("degraded", "consumer_receipt_missing");
+  }
+
+  const updatedAt = Date.parse(receipt.updated_at);
+  if (
+    !Number.isFinite(updatedAt)
+    || at.getTime() - updatedAt > SYNC_CONSUMER_RECEIPT_MAX_AGE_MS
+  ) {
+    return status("stale", "consumer_receipt_stale", receipt);
+  }
+  if (receipt.last_status === "failed") {
+    return status("degraded", "last_consumer_failed", receipt);
+  }
+  if (receipt.last_status === "rejected") {
+    return status("degraded", "last_consumer_rejected", receipt);
+  }
+  return status("healthy", null, receipt);
+}

--- a/cloudflare/worker/src/lib/env.ts
+++ b/cloudflare/worker/src/lib/env.ts
@@ -17,6 +17,22 @@ export interface QueueLike<T> {
   send(message: T): Promise<void>;
 }
 
+export interface QueueMessageLike<T> {
+  readonly id: string;
+  readonly body: T;
+  readonly attempts: number;
+  readonly timestamp?: Date;
+  ack(): void;
+  retry(options?: { delaySeconds?: number }): void;
+}
+
+export interface QueueBatchLike<T> {
+  readonly queue: string;
+  readonly messages: QueueMessageLike<T>[];
+  ackAll?(): void;
+  retryAll?(options?: { delaySeconds?: number }): void;
+}
+
 export interface DurableObjectStateLike {
   id?: {
     toString(): string;
@@ -31,10 +47,20 @@ export interface DurableObjectNamespaceLike {
 }
 
 export interface SyncJobMessage {
+  schemaVersion: "teamforge.sync-job.v1";
   jobId: string;
   workspaceId: string;
+  projectId: string;
   source: "clockify" | "github" | "huly" | "slack";
-  jobType: string;
+  jobType: "project_sync";
+  requestedAt: string;
+}
+
+export interface LegacyTeamSnapshotMessage {
+  jobId: string;
+  workspaceId: string;
+  source: "huly";
+  jobType: "team_snapshot";
 }
 
 export interface Env {
@@ -80,7 +106,7 @@ export interface Env {
   TF_REPORTING_WORKSPACE_ID?: string;
   TEAMFORGE_DB?: D1DatabaseLike;
   TEAMFORGE_ARTIFACTS?: R2BucketLike;
-  SYNC_QUEUE?: QueueLike<SyncJobMessage>;
+  SYNC_QUEUE?: QueueLike<SyncJobMessage | LegacyTeamSnapshotMessage>;
   WORKSPACE_LOCKS?: DurableObjectNamespaceLike;
   // Temporary internal shared secret for m2m calls (e.g. parity, Hermes) when CF Access service tokens have compatibility issues with Worker routes.
   // Used as alternative to TF_CREDENTIAL_ENVELOPE_KEY for app routes. Caller sends header "X-TeamForge-Internal-Secret".

--- a/cloudflare/worker/src/lib/env.ts
+++ b/cloudflare/worker/src/lib/env.ts
@@ -47,7 +47,7 @@ export interface DurableObjectNamespaceLike {
 }
 
 export interface SyncJobMessage {
-  schemaVersion: "teamforge.sync-job.v1";
+  schema: "teamforge.sync-job.v1";
   jobId: string;
   workspaceId: string;
   projectId: string;

--- a/cloudflare/worker/src/lib/sync-control-plane.ts
+++ b/cloudflare/worker/src/lib/sync-control-plane.ts
@@ -9,7 +9,7 @@ import {
 } from "./huly-api";
 import { acquireProjectLock } from "./locks";
 import { execute, nanoid, now, queryAll, queryFirst } from "./db";
-import type { D1DatabaseLike, Env } from "./env";
+import type { D1DatabaseLike, Env, SyncJobMessage } from "./env";
 import { getProjectGraph, type ProjectGraph } from "./project-registry";
 
 type OwnershipDomain = "engineering" | "execution_admin" | "milestone";
@@ -536,6 +536,72 @@ function buildPromotionBody(mapping: SyncEntityMappingRow): string {
   const payload = safeJsonParse<Record<string, unknown>>(mapping.payload_json) ?? {};
   const body = typeof payload.description === "string" ? payload.description : "";
   return `${body}\n\n---\nPromoted from TeamForge execution item${mapping.huly_entity_id ? ` (${mapping.huly_entity_id})` : ""}.`;
+}
+
+export async function runQueuedProjectSync(
+  env: Env,
+  message: SyncJobMessage,
+  runId: string,
+): Promise<Record<string, unknown>> {
+  const db = env.TEAMFORGE_DB;
+  if (!db) {
+    throw new Error("TeamForge database binding is unavailable.");
+  }
+  const graph = await getProjectGraph(db, message.projectId);
+  if (
+    !graph
+    || graph.project.workspaceId !== message.workspaceId
+  ) {
+    throw new Error("The queued project scope is unavailable.");
+  }
+
+  const context: SyncContext = {
+    db,
+    env,
+    graph,
+    workspaceId: message.workspaceId,
+    actorId: `queue:${message.source}`,
+    jobId: message.jobId,
+    runId,
+    githubClient: null,
+    hulyClient: null,
+    hulyActorSocialId: null,
+    stats: {
+      updatedMappings: 0,
+      conflictsOpened: 0,
+      journalCompleted: 0,
+      journalFailed: 0,
+    },
+  };
+
+  const lock = await acquireProjectLock(env, message.projectId, message.jobId);
+  try {
+    if (message.source === "github") {
+      if (!env.TF_GITHUB_TOKEN_GLOBAL?.trim()) {
+        throw new Error("The GitHub sync adapter is unavailable.");
+      }
+      context.githubClient = new GithubApiClient(env.TF_GITHUB_TOKEN_GLOBAL);
+      await syncGithubMilestones(context);
+      await syncGithubEngineeringIssues(context);
+    } else if (message.source === "huly") {
+      if (!env.TF_HULY_USER_TOKEN_GLOBAL?.trim()) {
+        throw new Error("The Huly sync adapter is unavailable.");
+      }
+      context.hulyClient = await HulyApiClient.connect(env.TF_HULY_USER_TOKEN_GLOBAL);
+      const account = await context.hulyClient.getAccountInfo();
+      context.hulyActorSocialId = resolveHulyActorSocialId(account);
+      await syncHulyExecutionIssues(context);
+      await detectHulyMilestoneDrift(context);
+    } else {
+      // Clockify and Slack remain valid frozen sources, but this control-plane
+      // module has no project adapter for them yet. Failing closed gives the
+      // Queue retry/DLQ path truthful evidence instead of claiming success.
+      throw new Error("The selected project sync adapter is unavailable.");
+    }
+    return { ...context.stats };
+  } finally {
+    await lock.release();
+  }
 }
 
 async function runProjectSync(

--- a/cloudflare/worker/src/lib/sync-queue.test.ts
+++ b/cloudflare/worker/src/lib/sync-queue.test.ts
@@ -19,7 +19,7 @@ interface JobRow {
 
 function messageBody(overrides: Partial<TeamForgeSyncJobMessage> = {}): TeamForgeSyncJobMessage {
   return {
-    schemaVersion: SYNC_JOB_SCHEMA_VERSION,
+    schema: SYNC_JOB_SCHEMA_VERSION,
     jobId: "job_123",
     workspaceId: "workspace_123",
     projectId: "project_123",
@@ -169,7 +169,17 @@ function env(db: D1DatabaseLike): Env {
 
 describe("teamforge.sync-job.v1", () => {
   it("accepts only the frozen bounded message", () => {
-    expect(parseSyncJobMessage(messageBody())).toEqual(messageBody());
+    const message = parseSyncJobMessage(messageBody());
+    expect(message).toEqual(messageBody());
+    expect(Object.keys(message ?? {}).sort()).toEqual([
+      "schema",
+      "jobId",
+      "workspaceId",
+      "source",
+      "jobType",
+      "projectId",
+      "requestedAt",
+    ].sort());
     expect(parseSyncJobMessage(messageBody({ jobType: "team_snapshot" as "project_sync" }))).toBeNull();
     expect(parseSyncJobMessage(messageBody({ source: "internal" as "github" }))).toBeNull();
     expect(parseSyncJobMessage(messageBody({ projectId: "x".repeat(129) }))).toBeNull();
@@ -207,7 +217,7 @@ describe("teamforge.sync-job.v1", () => {
     expect(response.status).toBe(202);
     expect(send).toHaveBeenCalledTimes(1);
     expect(send.mock.calls[0][0]).toEqual({
-      schemaVersion: SYNC_JOB_SCHEMA_VERSION,
+      schema: SYNC_JOB_SCHEMA_VERSION,
       jobId: expect.any(String),
       workspaceId: "workspace_123",
       projectId: "project_123",

--- a/cloudflare/worker/src/lib/sync-queue.test.ts
+++ b/cloudflare/worker/src/lib/sync-queue.test.ts
@@ -7,11 +7,12 @@ import {
   type TeamForgeSyncJobMessage,
 } from "./sync-queue";
 import { handlePostSyncJob } from "../routes/sync";
+import { handlePostTeamRefresh } from "../routes/team";
 
 interface JobRow {
   id: string;
   workspace_id: string;
-  project_id: string;
+  project_id: string | null;
   source: string;
   job_type: string;
   status: string;
@@ -54,11 +55,18 @@ function fakeBatch(message: QueueMessageLike<unknown>): QueueBatchLike<unknown> 
   return { queue: "teamforge-sync", messages: [message] };
 }
 
-function makeQueueDb(initialJob?: Partial<JobRow>) {
+function makeQueueDb(
+  initialJob?: Partial<JobRow>,
+  options: {
+    failSyncRunInsert?: boolean;
+    failCompletedJobUpdateOnce?: boolean;
+  } = {},
+) {
   const jobs = new Map<string, JobRow>();
   const runs = new Map<string, Record<string, unknown>>();
   const receipts = new Map<string, Record<string, unknown>>();
   const calls: Array<{ sql: string; values: unknown[] }> = [];
+  let completedJobUpdateFailures = 0;
   if (initialJob) {
     const row: JobRow = {
       id: "job_123",
@@ -91,6 +99,9 @@ function makeQueueDb(initialJob?: Partial<JobRow>) {
               return { results: [] as T[] };
             },
             async run() {
+              if (options.failSyncRunInsert && sql.includes("INSERT INTO sync_runs")) {
+                throw new Error("deterministic sync_runs insert failure");
+              }
               if (sql.includes("UPDATE sync_jobs") && sql.includes("status = 'running'")) {
                 const id = values[values.length - 1] as string;
                 const job = jobs.get(id);
@@ -100,18 +111,31 @@ function makeQueueDb(initialJob?: Partial<JobRow>) {
                 job.status = "running";
                 return { success: true, meta: { changes: 1 } };
               }
-              if (sql.includes("INSERT INTO sync_runs")) {
+              if (sql.includes("INTO sync_runs")) {
+                const hasFailureEvidence = sql.includes("error_code");
                 runs.set(values[0] as string, {
                   id: values[0],
                   status: values[4],
-                  error_code: null,
-                  error_message: null,
+                  error_code: hasFailureEvidence ? values[5] : null,
+                  error_message: hasFailureEvidence ? values[6] : null,
                 });
                 return { success: true, meta: { changes: 1 } };
+              }
+              if (sql.includes("queue_message_id")) {
+                const job = jobs.get(values[values.length - 1] as string);
+                return { success: true, meta: { changes: job ? 1 : 0 } };
               }
               if (sql.includes("UPDATE sync_jobs")) {
                 const id = values[values.length - 1] as string;
                 const job = jobs.get(id);
+                if (
+                  options.failCompletedJobUpdateOnce
+                  && values[0] === "completed"
+                  && completedJobUpdateFailures === 0
+                ) {
+                  completedJobUpdateFailures += 1;
+                  throw new Error("deterministic completion write failure");
+                }
                 if (job) job.status = values[0] as string;
                 return { success: true, meta: { changes: job ? 1 : 0 } };
               }
@@ -141,13 +165,14 @@ function makeQueueDb(initialJob?: Partial<JobRow>) {
                 return { success: true, meta: { changes: 1 } };
               }
               if (sql.includes("INSERT INTO sync_jobs")) {
+                const hasProjectId = sql.includes("project_id");
                 const row: JobRow = {
                   id: values[0] as string,
                   workspace_id: values[1] as string,
-                  project_id: values[2] as string,
-                  source: values[3] as string,
-                  job_type: values[4] as string,
-                  status: values[5] as string,
+                  project_id: hasProjectId ? values[2] as string : null,
+                  source: values[hasProjectId ? 3 : 2] as string,
+                  job_type: values[hasProjectId ? 4 : 3] as string,
+                  status: values[hasProjectId ? 5 : 4] as string,
                 };
                 jobs.set(row.id, row);
                 return { success: true, meta: { changes: 1 } };
@@ -226,12 +251,83 @@ describe("teamforge.sync-job.v1", () => {
       requestedAt: expect.stringMatching(/Z$/),
     });
   });
+
+  it("fails terminally when the Queue binding is missing", async () => {
+    const mock = makeQueueDb();
+    const response = await handlePostSyncJob(
+      env(mock.db),
+      new Request("https://forge.example/v1/sync/jobs", {
+        method: "POST",
+        body: JSON.stringify({
+          workspace_id: "workspace_123",
+          project_id: "project_123",
+          source: "github",
+        }),
+      }),
+    );
+    const payload = await response.json() as { error: { code: string } };
+
+    expect(response.status).toBe(503);
+    expect(payload.error.code).toBe("sync_queue_unavailable");
+    expect(Array.from(mock.jobs.values())[0]?.status).toBe("failed");
+    expect(Array.from(mock.runs.values())[0]).toMatchObject({
+      status: "failed",
+      error_code: "sync_queue_unavailable",
+    });
+  });
+
+  it("persists bounded terminal evidence when Queue send rejects", async () => {
+    const mock = makeQueueDb();
+    const response = await handlePostSyncJob(
+      {
+        ...env(mock.db),
+        SYNC_QUEUE: {
+          async send() {
+            throw new Error("Bearer producer-secret external body");
+          },
+        },
+      },
+      new Request("https://forge.example/v1/sync/jobs", {
+        method: "POST",
+        body: JSON.stringify({
+          workspace_id: "workspace_123",
+          project_id: "project_123",
+          source: "github",
+        }),
+      }),
+    );
+    const persistedValues = JSON.stringify(mock.calls.flatMap(({ values }) => values));
+
+    expect(response.status).toBe(503);
+    expect(Array.from(mock.jobs.values())[0]?.status).toBe("failed");
+    expect(Array.from(mock.runs.values())[0]).toMatchObject({
+      status: "failed",
+      error_code: "sync_queue_send_failed",
+    });
+    expect(persistedValues).not.toContain("producer-secret");
+    expect(persistedValues).not.toContain("external body");
+  });
 });
 
 describe("sync queue consumer", () => {
   it("fails closed before D1 and adapters for an unknown source", async () => {
     const mock = makeQueueDb({ status: "queued" });
     const queueMessage = fakeMessage(messageBody({ source: "unknown" as "github" }));
+    const runAdapter = vi.fn(async () => ({}));
+
+    await handleSyncQueueBatch(fakeBatch(queueMessage), env(mock.db), { runAdapter });
+
+    expect(mock.calls).toHaveLength(0);
+    expect(runAdapter).not.toHaveBeenCalled();
+    expect(queueMessage.acked).toBe(true);
+    expect(queueMessage.retried).toBe(false);
+  });
+
+  it("rejects a source array before D1 and adapters", async () => {
+    const mock = makeQueueDb({ status: "queued" });
+    const queueMessage = fakeMessage(messageBody({
+      source: ["github"] as unknown as "github",
+    }));
     const runAdapter = vi.fn(async () => ({}));
 
     await handleSyncQueueBatch(fakeBatch(queueMessage), env(mock.db), { runAdapter });
@@ -309,6 +405,124 @@ describe("sync queue consumer", () => {
     expect(mock.receipts.get("runtime_test")?.last_status).toBe("failed");
     expect(queueMessage.retried).toBe(true);
     expect(queueMessage.acked).toBe(false);
+  });
+
+  it("recovers a claimed job when sync run insertion fails", async () => {
+    const mock = makeQueueDb(
+      { status: "queued" },
+      { failSyncRunInsert: true },
+    );
+    const queueMessage = fakeMessage(messageBody());
+    const runAdapter = vi.fn(async () => ({}));
+
+    await handleSyncQueueBatch(fakeBatch(queueMessage), env(mock.db), {
+      runAdapter,
+      runtimeId: "runtime_test",
+      now: () => new Date("2026-07-28T10:01:00.000Z"),
+    });
+
+    expect(runAdapter).not.toHaveBeenCalled();
+    expect(mock.jobs.get("job_123")?.status).toBe("queued");
+    expect(mock.receipts.get("runtime_test")?.last_status).toBe("failed");
+    expect(queueMessage.retried).toBe(true);
+    expect(queueMessage.acked).toBe(false);
+  });
+
+  it("does not rerun an adapter after a completion persistence failure", async () => {
+    const mock = makeQueueDb(
+      { status: "queued" },
+      { failCompletedJobUpdateOnce: true },
+    );
+    const runAdapter = vi.fn(async () => ({ updatedMappings: 1 }));
+    const firstDelivery = fakeMessage(messageBody());
+
+    await handleSyncQueueBatch(fakeBatch(firstDelivery), env(mock.db), {
+      runAdapter,
+      runtimeId: "runtime_test",
+      now: () => new Date("2026-07-28T10:01:00.000Z"),
+    });
+    expect(firstDelivery.retried).toBe(true);
+    expect(mock.jobs.get("job_123")?.status).toBe("failed");
+    expect(Array.from(mock.runs.values())[0]).toMatchObject({
+      status: "failed",
+      error_code: "sync_completion_persistence_failed",
+    });
+
+    const redelivery = fakeMessage(messageBody(), {
+      id: "message_124",
+      attempts: 2,
+    });
+    await handleSyncQueueBatch(fakeBatch(redelivery), env(mock.db), {
+      runAdapter,
+      runtimeId: "runtime_test",
+      now: () => new Date("2026-07-28T10:02:00.000Z"),
+    });
+
+    expect(runAdapter).toHaveBeenCalledTimes(1);
+    expect(redelivery.acked).toBe(true);
+    expect(redelivery.retried).toBe(false);
+  });
+
+  it("terminally rejects the exact legacy team refresh message without an adapter", async () => {
+    const mock = makeQueueDb();
+    let producedMessage: unknown;
+    const producerEnv: Env = {
+      ...env(mock.db),
+      SYNC_QUEUE: {
+        async send(message) {
+          producedMessage = message;
+        },
+      },
+    };
+    const response = await handlePostTeamRefresh(
+      producerEnv,
+      new Request("https://forge.example/v1/team/refresh", {
+        method: "POST",
+        body: JSON.stringify({ workspace_id: "workspace_123" }),
+      }),
+    );
+    expect(response.status).toBe(202);
+    expect(producedMessage).toEqual({
+      jobId: expect.any(String),
+      workspaceId: "workspace_123",
+      source: "huly",
+      jobType: "team_snapshot",
+    });
+
+    const queueMessage = fakeMessage(producedMessage);
+    const runAdapter = vi.fn(async () => ({}));
+    await handleSyncQueueBatch(fakeBatch(queueMessage), producerEnv, {
+      runAdapter,
+      runtimeId: "runtime_test",
+      now: () => new Date("2026-07-28T10:01:00.000Z"),
+    });
+
+    expect(runAdapter).not.toHaveBeenCalled();
+    expect(Array.from(mock.jobs.values())[0]?.status).toBe("failed");
+    expect(Array.from(mock.runs.values())[0]).toMatchObject({
+      status: "failed",
+      error_code: "job_type_unsupported",
+    });
+    expect(mock.receipts.get("runtime_test")?.last_status).toBe("rejected");
+    expect(queueMessage.acked).toBe(true);
+    expect(queueMessage.retried).toBe(false);
+  });
+
+  it("acks malformed legacy refresh shapes before D1", async () => {
+    const mock = makeQueueDb();
+    const queueMessage = fakeMessage({
+      jobId: "job_123",
+      workspaceId: "workspace_123",
+      source: ["huly"],
+      jobType: "team_snapshot",
+    });
+    const runAdapter = vi.fn(async () => ({}));
+
+    await handleSyncQueueBatch(fakeBatch(queueMessage), env(mock.db), { runAdapter });
+
+    expect(mock.calls).toHaveLength(0);
+    expect(runAdapter).not.toHaveBeenCalled();
+    expect(queueMessage.acked).toBe(true);
   });
 
   it("marks exhausted work failed before its final retry reaches the DLQ", async () => {

--- a/cloudflare/worker/src/lib/sync-queue.test.ts
+++ b/cloudflare/worker/src/lib/sync-queue.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, it, vi } from "vitest";
+import type { D1DatabaseLike, Env, QueueBatchLike, QueueMessageLike } from "./env";
+import {
+  SYNC_JOB_SCHEMA_VERSION,
+  handleSyncQueueBatch,
+  parseSyncJobMessage,
+  type TeamForgeSyncJobMessage,
+} from "./sync-queue";
+import { handlePostSyncJob } from "../routes/sync";
+
+interface JobRow {
+  id: string;
+  workspace_id: string;
+  project_id: string;
+  source: string;
+  job_type: string;
+  status: string;
+}
+
+function messageBody(overrides: Partial<TeamForgeSyncJobMessage> = {}): TeamForgeSyncJobMessage {
+  return {
+    schemaVersion: SYNC_JOB_SCHEMA_VERSION,
+    jobId: "job_123",
+    workspaceId: "workspace_123",
+    projectId: "project_123",
+    source: "github",
+    jobType: "project_sync",
+    requestedAt: "2026-07-28T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function fakeMessage(
+  body: unknown,
+  overrides: Partial<QueueMessageLike<unknown>> = {},
+): QueueMessageLike<unknown> & { acked: boolean; retried: boolean } {
+  return {
+    id: "message_123",
+    body,
+    attempts: 1,
+    acked: false,
+    retried: false,
+    ack() {
+      this.acked = true;
+    },
+    retry() {
+      this.retried = true;
+    },
+    ...overrides,
+  };
+}
+
+function fakeBatch(message: QueueMessageLike<unknown>): QueueBatchLike<unknown> {
+  return { queue: "teamforge-sync", messages: [message] };
+}
+
+function makeQueueDb(initialJob?: Partial<JobRow>) {
+  const jobs = new Map<string, JobRow>();
+  const runs = new Map<string, Record<string, unknown>>();
+  const receipts = new Map<string, Record<string, unknown>>();
+  const calls: Array<{ sql: string; values: unknown[] }> = [];
+  if (initialJob) {
+    const row: JobRow = {
+      id: "job_123",
+      workspace_id: "workspace_123",
+      project_id: "project_123",
+      source: "github",
+      job_type: "project_sync",
+      status: "queued",
+      ...initialJob,
+    };
+    jobs.set(row.id, row);
+  }
+
+  const db = {
+    prepare(sql: string) {
+      return {
+        bind(...values: unknown[]) {
+          calls.push({ sql, values });
+          return {
+            async first<T>() {
+              if (sql.includes("FROM sync_jobs")) {
+                return (jobs.get(values[0] as string) ?? null) as T | null;
+              }
+              if (sql.includes("FROM sync_runtime_receipts")) {
+                return (Array.from(receipts.values())[0] ?? null) as T | null;
+              }
+              return null;
+            },
+            async all<T>() {
+              return { results: [] as T[] };
+            },
+            async run() {
+              if (sql.includes("UPDATE sync_jobs") && sql.includes("status = 'running'")) {
+                const id = values[values.length - 1] as string;
+                const job = jobs.get(id);
+                if (!job || job.status !== "queued") {
+                  return { success: true, meta: { changes: 0 } };
+                }
+                job.status = "running";
+                return { success: true, meta: { changes: 1 } };
+              }
+              if (sql.includes("INSERT INTO sync_runs")) {
+                runs.set(values[0] as string, {
+                  id: values[0],
+                  status: values[4],
+                  error_code: null,
+                  error_message: null,
+                });
+                return { success: true, meta: { changes: 1 } };
+              }
+              if (sql.includes("UPDATE sync_jobs")) {
+                const id = values[values.length - 1] as string;
+                const job = jobs.get(id);
+                if (job) job.status = values[0] as string;
+                return { success: true, meta: { changes: job ? 1 : 0 } };
+              }
+              if (sql.includes("UPDATE sync_runs")) {
+                const id = values[values.length - 1] as string;
+                const run = runs.get(id);
+                if (run) {
+                  run.status = values[0];
+                  if (sql.includes("error_code")) {
+                    run.error_code = values[1];
+                    run.error_message = values[2];
+                  }
+                }
+                return { success: true, meta: { changes: run ? 1 : 0 } };
+              }
+              if (sql.includes("sync_runtime_receipts")) {
+                receipts.set(values[1] as string, {
+                  schema_version: values[0],
+                  runtime_id: values[1],
+                  last_message_id: values[2],
+                  last_job_id: values[3],
+                  last_status: values[4],
+                  last_consumed_at: values[5],
+                  last_terminal_at: values[6],
+                  updated_at: values[7],
+                });
+                return { success: true, meta: { changes: 1 } };
+              }
+              if (sql.includes("INSERT INTO sync_jobs")) {
+                const row: JobRow = {
+                  id: values[0] as string,
+                  workspace_id: values[1] as string,
+                  project_id: values[2] as string,
+                  source: values[3] as string,
+                  job_type: values[4] as string,
+                  status: values[5] as string,
+                };
+                jobs.set(row.id, row);
+                return { success: true, meta: { changes: 1 } };
+              }
+              return { success: true, meta: { changes: 1 } };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as D1DatabaseLike;
+
+  return { db, jobs, runs, receipts, calls };
+}
+
+function env(db: D1DatabaseLike): Env {
+  return { TF_ENV: "test", TEAMFORGE_DB: db };
+}
+
+describe("teamforge.sync-job.v1", () => {
+  it("accepts only the frozen bounded message", () => {
+    expect(parseSyncJobMessage(messageBody())).toEqual(messageBody());
+    expect(parseSyncJobMessage(messageBody({ jobType: "team_snapshot" as "project_sync" }))).toBeNull();
+    expect(parseSyncJobMessage(messageBody({ source: "internal" as "github" }))).toBeNull();
+    expect(parseSyncJobMessage(messageBody({ projectId: "x".repeat(129) }))).toBeNull();
+    expect(parseSyncJobMessage(messageBody({ workspaceId: " " }))).toBeNull();
+    expect(parseSyncJobMessage(messageBody({ requestedAt: "yesterday" }))).toBeNull();
+  });
+
+  it("producer requires project_id and sends exactly the frozen message", async () => {
+    const mock = makeQueueDb();
+    const send = vi.fn(async () => undefined);
+    const producerEnv: Env = { ...env(mock.db), SYNC_QUEUE: { send } };
+    const missing = await handlePostSyncJob(
+      producerEnv,
+      new Request("https://forge.example/v1/sync/jobs", {
+        method: "POST",
+        body: JSON.stringify({ workspace_id: "workspace_123", source: "github" }),
+      }),
+    );
+    expect(missing.status).toBe(400);
+    expect(send).not.toHaveBeenCalled();
+
+    const response = await handlePostSyncJob(
+      producerEnv,
+      new Request("https://forge.example/v1/sync/jobs", {
+        method: "POST",
+        body: JSON.stringify({
+          workspace_id: "workspace_123",
+          project_id: "project_123",
+          source: "github",
+          job_type: "project_sync",
+          payload: { token: "must-not-be-queued" },
+        }),
+      }),
+    );
+    expect(response.status).toBe(202);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0][0]).toEqual({
+      schemaVersion: SYNC_JOB_SCHEMA_VERSION,
+      jobId: expect.any(String),
+      workspaceId: "workspace_123",
+      projectId: "project_123",
+      source: "github",
+      jobType: "project_sync",
+      requestedAt: expect.stringMatching(/Z$/),
+    });
+  });
+});
+
+describe("sync queue consumer", () => {
+  it("fails closed before D1 and adapters for an unknown source", async () => {
+    const mock = makeQueueDb({ status: "queued" });
+    const queueMessage = fakeMessage(messageBody({ source: "unknown" as "github" }));
+    const runAdapter = vi.fn(async () => ({}));
+
+    await handleSyncQueueBatch(fakeBatch(queueMessage), env(mock.db), { runAdapter });
+
+    expect(mock.calls).toHaveLength(0);
+    expect(runAdapter).not.toHaveBeenCalled();
+    expect(queueMessage.acked).toBe(true);
+    expect(queueMessage.retried).toBe(false);
+  });
+
+  it("acks an already completed job without rerunning it", async () => {
+    const mock = makeQueueDb({ status: "completed" });
+    const queueMessage = fakeMessage(messageBody());
+    const runAdapter = vi.fn(async () => ({}));
+
+    await handleSyncQueueBatch(fakeBatch(queueMessage), env(mock.db), { runAdapter });
+
+    expect(runAdapter).not.toHaveBeenCalled();
+    expect(queueMessage.acked).toBe(true);
+    expect(queueMessage.retried).toBe(false);
+  });
+
+  it("atomically claims queued work and persists completed run and receipt", async () => {
+    const mock = makeQueueDb({ status: "queued" });
+    const queueMessage = fakeMessage(messageBody());
+    const runAdapter = vi.fn(async () => ({
+      updatedMappings: 2,
+      token: "must-not-be-persisted",
+    }));
+
+    await handleSyncQueueBatch(fakeBatch(queueMessage), env(mock.db), {
+      runAdapter,
+      runtimeId: "runtime_test",
+      now: () => new Date("2026-07-28T10:01:00.000Z"),
+    });
+
+    expect(mock.calls.some(
+      ({ sql }) => sql.includes("status = 'running'") && sql.includes("status = 'queued'"),
+    )).toBe(true);
+    expect(runAdapter).toHaveBeenCalledTimes(1);
+    expect(mock.jobs.get("job_123")?.status).toBe("completed");
+    expect(Array.from(mock.runs.values())[0]?.status).toBe("completed");
+    expect(JSON.stringify(mock.calls.flatMap(({ values }) => values)))
+      .not.toContain("must-not-be-persisted");
+    expect(mock.receipts.get("runtime_test")).toMatchObject({
+      schema_version: "teamforge.sync-runtime-receipt.v1",
+      runtime_id: "runtime_test",
+      last_message_id: "message_123",
+      last_job_id: "job_123",
+      last_status: "completed",
+    });
+    expect(queueMessage.acked).toBe(true);
+  });
+
+  it("persists bounded non-secret failure evidence before retry", async () => {
+    const mock = makeQueueDb({ status: "queued" });
+    const queueMessage = fakeMessage(messageBody());
+    const runAdapter = vi.fn(async () => {
+      throw new Error("Bearer super-secret-token external body " + "x".repeat(2_000));
+    });
+
+    await handleSyncQueueBatch(fakeBatch(queueMessage), env(mock.db), {
+      runAdapter,
+      runtimeId: "runtime_test",
+      now: () => new Date("2026-07-28T10:01:00.000Z"),
+    });
+
+    const persistedValues = JSON.stringify(mock.calls.flatMap(({ values }) => values));
+    expect(persistedValues).not.toContain("super-secret-token");
+    expect(persistedValues).not.toContain("external body");
+    expect(Array.from(mock.runs.values())[0]).toMatchObject({
+      status: "failed",
+      error_code: "sync_adapter_failed",
+    });
+    expect(mock.receipts.get("runtime_test")?.last_status).toBe("failed");
+    expect(queueMessage.retried).toBe(true);
+    expect(queueMessage.acked).toBe(false);
+  });
+
+  it("marks exhausted work failed before its final retry reaches the DLQ", async () => {
+    const mock = makeQueueDb({ status: "queued" });
+    const queueMessage = fakeMessage(messageBody(), { attempts: 4 });
+
+    await handleSyncQueueBatch(fakeBatch(queueMessage), env(mock.db), {
+      runAdapter: async () => {
+        throw new Error("adapter failure");
+      },
+      runtimeId: "runtime_test",
+      now: () => new Date("2026-07-28T10:01:00.000Z"),
+    });
+
+    expect(mock.jobs.get("job_123")?.status).toBe("failed");
+    expect(mock.receipts.get("runtime_test")?.last_status).toBe("failed");
+    expect(queueMessage.retried).toBe(true);
+  });
+});

--- a/cloudflare/worker/src/lib/sync-queue.ts
+++ b/cloudflare/worker/src/lib/sync-queue.ts
@@ -1,0 +1,357 @@
+import { nanoid } from "./db";
+import type {
+  D1DatabaseLike,
+  Env,
+  QueueBatchLike,
+  QueueMessageLike,
+  SyncJobMessage,
+} from "./env";
+import { runQueuedProjectSync } from "./sync-control-plane";
+
+export const SYNC_JOB_SCHEMA_VERSION = "teamforge.sync-job.v1" as const;
+export const SYNC_RUNTIME_RECEIPT_SCHEMA_VERSION =
+  "teamforge.sync-runtime-receipt.v1" as const;
+export const SYNC_QUEUE_RUNTIME_ID = "teamforge-sync-consumer" as const;
+
+const IDENTIFIER_MAX_BYTES = 128;
+const MAX_QUEUE_ATTEMPTS = 4;
+
+export type TeamForgeSyncJobMessage = SyncJobMessage;
+export type SyncRuntimeStatus = "completed" | "failed" | "rejected";
+
+interface SyncJobRow {
+  id: string;
+  workspace_id: string;
+  project_id: string | null;
+  source: string;
+  job_type: string;
+  status: string;
+}
+
+export interface SyncQueueDependencies {
+  runAdapter?: (
+    env: Env,
+    message: TeamForgeSyncJobMessage,
+    runId: string,
+  ) => Promise<Record<string, unknown>>;
+  now?: () => Date;
+  runtimeId?: string;
+}
+
+function utf8Length(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+function isBoundedIdentifier(value: unknown): value is string {
+  return typeof value === "string"
+    && value.trim().length > 0
+    && value.trim() === value
+    && utf8Length(value) <= IDENTIFIER_MAX_BYTES;
+}
+
+function isCanonicalTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const milliseconds = Date.parse(value);
+  return Number.isFinite(milliseconds)
+    && new Date(milliseconds).toISOString() === value;
+}
+
+export function parseSyncJobMessage(input: unknown): TeamForgeSyncJobMessage | null {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return null;
+  const candidate = input as Record<string, unknown>;
+  const expectedKeys = [
+    "schemaVersion",
+    "jobId",
+    "workspaceId",
+    "projectId",
+    "source",
+    "jobType",
+    "requestedAt",
+  ];
+  if (
+    Object.keys(candidate).length !== expectedKeys.length
+    || expectedKeys.some((key) => !(key in candidate))
+  ) {
+    return null;
+  }
+  if (candidate.schemaVersion !== SYNC_JOB_SCHEMA_VERSION) return null;
+  if (!isBoundedIdentifier(candidate.jobId)) return null;
+  if (!isBoundedIdentifier(candidate.workspaceId)) return null;
+  if (!isBoundedIdentifier(candidate.projectId)) return null;
+  if (!["clockify", "github", "huly", "slack"].includes(String(candidate.source))) {
+    return null;
+  }
+  if (candidate.jobType !== "project_sync") return null;
+  if (!isCanonicalTimestamp(candidate.requestedAt)) return null;
+  return candidate as unknown as TeamForgeSyncJobMessage;
+}
+
+function terminalTimestamp(clock: () => Date): string {
+  return clock().toISOString();
+}
+
+function boundedRunStats(stats: Record<string, unknown>): Record<string, number> {
+  const allowedKeys = [
+    "updatedMappings",
+    "conflictsOpened",
+    "journalCompleted",
+    "journalFailed",
+  ] as const;
+  const bounded: Record<string, number> = {};
+  for (const key of allowedKeys) {
+    const value = stats[key];
+    if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+      bounded[key] = value;
+    }
+  }
+  return bounded;
+}
+
+async function readJob(
+  db: D1DatabaseLike,
+  jobId: string,
+): Promise<SyncJobRow | null> {
+  return db.prepare(
+    `SELECT id, workspace_id, project_id, source, job_type, status
+     FROM sync_jobs
+     WHERE id = ?`,
+  ).bind(jobId).first<SyncJobRow>();
+}
+
+async function writeReceipt(
+  db: D1DatabaseLike,
+  runtimeId: string,
+  queueMessageId: string,
+  jobId: string,
+  status: SyncRuntimeStatus,
+  consumedAt: string,
+  terminalAt: string,
+): Promise<void> {
+  await db.prepare(
+    `INSERT INTO sync_runtime_receipts
+      (schema_version, runtime_id, last_message_id, last_job_id, last_status,
+       last_consumed_at, last_terminal_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(runtime_id) DO UPDATE SET
+       schema_version = excluded.schema_version,
+       last_message_id = excluded.last_message_id,
+       last_job_id = excluded.last_job_id,
+       last_status = excluded.last_status,
+       last_consumed_at = excluded.last_consumed_at,
+       last_terminal_at = excluded.last_terminal_at,
+       updated_at = excluded.updated_at`,
+  ).bind(
+    SYNC_RUNTIME_RECEIPT_SCHEMA_VERSION,
+    runtimeId,
+    queueMessageId,
+    jobId,
+    status,
+    consumedAt,
+    terminalAt,
+    terminalAt,
+  ).run();
+}
+
+function jobMatchesMessage(
+  job: SyncJobRow,
+  message: TeamForgeSyncJobMessage,
+): boolean {
+  return job.workspace_id === message.workspaceId
+    && job.project_id === message.projectId
+    && job.source === message.source
+    && job.job_type === message.jobType;
+}
+
+async function rejectMessage(
+  db: D1DatabaseLike,
+  queueMessage: QueueMessageLike<unknown>,
+  message: TeamForgeSyncJobMessage,
+  runtimeId: string,
+  consumedAt: string,
+  clock: () => Date,
+): Promise<void> {
+  const finishedAt = terminalTimestamp(clock);
+  await writeReceipt(
+    db,
+    runtimeId,
+    queueMessage.id,
+    message.jobId,
+    "rejected",
+    consumedAt,
+    finishedAt,
+  );
+  queueMessage.ack();
+}
+
+async function processMessage(
+  queueMessage: QueueMessageLike<unknown>,
+  env: Env,
+  dependencies: SyncQueueDependencies,
+): Promise<void> {
+  // The envelope is untrusted. Validate it completely before touching D1 or
+  // selecting a source adapter.
+  const message = parseSyncJobMessage(queueMessage.body);
+  if (!message) {
+    queueMessage.ack();
+    return;
+  }
+
+  const db = env.TEAMFORGE_DB;
+  if (!db) {
+    queueMessage.retry();
+    return;
+  }
+
+  const clock = dependencies.now ?? (() => new Date());
+  const runtimeId = dependencies.runtimeId ?? SYNC_QUEUE_RUNTIME_ID;
+  const consumedAt = terminalTimestamp(clock);
+  const job = await readJob(db, message.jobId);
+  if (!job || !jobMatchesMessage(job, message)) {
+    await rejectMessage(
+      db,
+      queueMessage,
+      message,
+      runtimeId,
+      consumedAt,
+      clock,
+    );
+    return;
+  }
+
+  if (job.status === "completed") {
+    const finishedAt = terminalTimestamp(clock);
+    await writeReceipt(
+      db,
+      runtimeId,
+      queueMessage.id,
+      message.jobId,
+      "completed",
+      consumedAt,
+      finishedAt,
+    );
+    queueMessage.ack();
+    return;
+  }
+  if (job.status !== "queued") {
+    queueMessage.retry();
+    return;
+  }
+
+  const startedAt = terminalTimestamp(clock);
+  const claim = await db.prepare(
+    `UPDATE sync_jobs
+     SET status = 'running', started_at = COALESCE(started_at, ?), updated_at = ?
+     WHERE id = ? AND status = 'queued'`,
+  ).bind(startedAt, startedAt, message.jobId).run();
+  if ((claim.meta?.changes ?? 0) !== 1) {
+    const racedJob = await readJob(db, message.jobId);
+    if (racedJob?.status === "completed") {
+      const finishedAt = terminalTimestamp(clock);
+      await writeReceipt(
+        db,
+        runtimeId,
+        queueMessage.id,
+        message.jobId,
+        "completed",
+        consumedAt,
+        finishedAt,
+      );
+      queueMessage.ack();
+    } else {
+      queueMessage.retry();
+    }
+    return;
+  }
+
+  const runId = nanoid();
+  await db.prepare(
+    `INSERT INTO sync_runs
+      (id, workspace_id, source, job_id, status, started_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).bind(
+    runId,
+    message.workspaceId,
+    message.source,
+    message.jobId,
+    "running",
+    startedAt,
+    startedAt,
+  ).run();
+
+  try {
+    const runAdapter = dependencies.runAdapter ?? runQueuedProjectSync;
+    const stats = await runAdapter(env, message, runId);
+    const finishedAt = terminalTimestamp(clock);
+    await db.prepare(
+      `UPDATE sync_runs
+       SET status = ?, stats_json = ?, finished_at = ?
+       WHERE id = ?`,
+    ).bind(
+      "completed",
+      JSON.stringify(boundedRunStats(stats)),
+      finishedAt,
+      runId,
+    ).run();
+    await db.prepare(
+      `UPDATE sync_jobs
+       SET status = ?, finished_at = ?, updated_at = ?
+       WHERE id = ?`,
+    ).bind("completed", finishedAt, finishedAt, message.jobId).run();
+    await writeReceipt(
+      db,
+      runtimeId,
+      queueMessage.id,
+      message.jobId,
+      "completed",
+      consumedAt,
+      finishedAt,
+    );
+    queueMessage.ack();
+  } catch {
+    // Persist only fixed, bounded evidence. Adapter exceptions can contain
+    // vendor response bodies or credentials and must never enter D1.
+    const finishedAt = terminalTimestamp(clock);
+    await db.prepare(
+      `UPDATE sync_runs
+       SET status = ?, error_code = ?, error_message = ?, finished_at = ?
+       WHERE id = ?`,
+    ).bind(
+      "failed",
+      "sync_adapter_failed",
+      "The selected sync adapter failed.",
+      finishedAt,
+      runId,
+    ).run();
+    const exhausted = queueMessage.attempts >= MAX_QUEUE_ATTEMPTS;
+    await db.prepare(
+      `UPDATE sync_jobs
+       SET status = ?, finished_at = ?, updated_at = ?
+       WHERE id = ?`,
+    ).bind(
+      exhausted ? "failed" : "queued",
+      exhausted ? finishedAt : null,
+      finishedAt,
+      message.jobId,
+    ).run();
+    await writeReceipt(
+      db,
+      runtimeId,
+      queueMessage.id,
+      message.jobId,
+      "failed",
+      consumedAt,
+      finishedAt,
+    );
+    queueMessage.retry();
+  }
+}
+
+export async function handleSyncQueueBatch(
+  batch: QueueBatchLike<unknown>,
+  env: Env,
+  dependencies: SyncQueueDependencies = {},
+): Promise<void> {
+  for (const queueMessage of batch.messages) {
+    await processMessage(queueMessage, env, dependencies);
+  }
+}

--- a/cloudflare/worker/src/lib/sync-queue.ts
+++ b/cloudflare/worker/src/lib/sync-queue.ts
@@ -60,7 +60,7 @@ export function parseSyncJobMessage(input: unknown): TeamForgeSyncJobMessage | n
   if (!input || typeof input !== "object" || Array.isArray(input)) return null;
   const candidate = input as Record<string, unknown>;
   const expectedKeys = [
-    "schemaVersion",
+    "schema",
     "jobId",
     "workspaceId",
     "projectId",
@@ -74,7 +74,7 @@ export function parseSyncJobMessage(input: unknown): TeamForgeSyncJobMessage | n
   ) {
     return null;
   }
-  if (candidate.schemaVersion !== SYNC_JOB_SCHEMA_VERSION) return null;
+  if (candidate.schema !== SYNC_JOB_SCHEMA_VERSION) return null;
   if (!isBoundedIdentifier(candidate.jobId)) return null;
   if (!isBoundedIdentifier(candidate.workspaceId)) return null;
   if (!isBoundedIdentifier(candidate.projectId)) return null;

--- a/cloudflare/worker/src/lib/sync-queue.ts
+++ b/cloudflare/worker/src/lib/sync-queue.ts
@@ -2,6 +2,7 @@ import { nanoid } from "./db";
 import type {
   D1DatabaseLike,
   Env,
+  LegacyTeamSnapshotMessage,
   QueueBatchLike,
   QueueMessageLike,
   SyncJobMessage,
@@ -17,6 +18,7 @@ const IDENTIFIER_MAX_BYTES = 128;
 const MAX_QUEUE_ATTEMPTS = 4;
 
 export type TeamForgeSyncJobMessage = SyncJobMessage;
+export type TeamForgeLegacyTeamSnapshotMessage = LegacyTeamSnapshotMessage;
 export type SyncRuntimeStatus = "completed" | "failed" | "rejected";
 
 interface SyncJobRow {
@@ -78,12 +80,36 @@ export function parseSyncJobMessage(input: unknown): TeamForgeSyncJobMessage | n
   if (!isBoundedIdentifier(candidate.jobId)) return null;
   if (!isBoundedIdentifier(candidate.workspaceId)) return null;
   if (!isBoundedIdentifier(candidate.projectId)) return null;
-  if (!["clockify", "github", "huly", "slack"].includes(String(candidate.source))) {
+  if (
+    typeof candidate.source !== "string"
+    || !["clockify", "github", "huly", "slack"].includes(candidate.source)
+  ) {
     return null;
   }
   if (candidate.jobType !== "project_sync") return null;
   if (!isCanonicalTimestamp(candidate.requestedAt)) return null;
   return candidate as unknown as TeamForgeSyncJobMessage;
+}
+
+export function parseLegacyTeamSnapshotMessage(
+  input: unknown,
+): TeamForgeLegacyTeamSnapshotMessage | null {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return null;
+  const candidate = input as Record<string, unknown>;
+  const expectedKeys = ["jobId", "workspaceId", "source", "jobType"];
+  if (
+    Object.keys(candidate).length !== expectedKeys.length
+    || expectedKeys.some((key) => !(key in candidate))
+  ) {
+    return null;
+  }
+  if (!isBoundedIdentifier(candidate.jobId)) return null;
+  if (!isBoundedIdentifier(candidate.workspaceId)) return null;
+  if (typeof candidate.source !== "string" || candidate.source !== "huly") {
+    return null;
+  }
+  if (candidate.jobType !== "team_snapshot") return null;
+  return candidate as unknown as TeamForgeLegacyTeamSnapshotMessage;
 }
 
 function terminalTimestamp(clock: () => Date): string {
@@ -183,6 +209,239 @@ async function rejectMessage(
   queueMessage.ack();
 }
 
+async function attempt(operation: () => Promise<void>): Promise<boolean> {
+  try {
+    await operation();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function writeUnsupportedLegacyRun(
+  db: D1DatabaseLike,
+  job: SyncJobRow,
+  timestamp: string,
+): Promise<void> {
+  await db.prepare(
+    `INSERT OR IGNORE INTO sync_runs
+      (id, workspace_id, source, job_id, status, error_code, error_message,
+       started_at, finished_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).bind(
+    `unsupported_${job.id}`,
+    job.workspace_id,
+    job.source,
+    job.id,
+    "failed",
+    "job_type_unsupported",
+    "The legacy team_snapshot Queue job is unsupported.",
+    timestamp,
+    timestamp,
+    timestamp,
+  ).run();
+}
+
+async function processLegacyTeamSnapshot(
+  queueMessage: QueueMessageLike<unknown>,
+  env: Env,
+  message: TeamForgeLegacyTeamSnapshotMessage,
+  dependencies: SyncQueueDependencies,
+): Promise<void> {
+  const db = env.TEAMFORGE_DB;
+  if (!db) {
+    queueMessage.retry();
+    return;
+  }
+  const clock = dependencies.now ?? (() => new Date());
+  const runtimeId = dependencies.runtimeId ?? SYNC_QUEUE_RUNTIME_ID;
+  const consumedAt = terminalTimestamp(clock);
+  let job = await readJob(db, message.jobId);
+  if (
+    !job
+    || job.workspace_id !== message.workspaceId
+    || job.source !== message.source
+    || job.job_type !== message.jobType
+  ) {
+    await writeReceipt(
+      db,
+      runtimeId,
+      queueMessage.id,
+      message.jobId,
+      "rejected",
+      consumedAt,
+      terminalTimestamp(clock),
+    );
+    queueMessage.ack();
+    return;
+  }
+
+  if (job.status === "completed") {
+    await writeReceipt(
+      db,
+      runtimeId,
+      queueMessage.id,
+      message.jobId,
+      "rejected",
+      consumedAt,
+      terminalTimestamp(clock),
+    );
+    queueMessage.ack();
+    return;
+  }
+
+  const finishedAt = terminalTimestamp(clock);
+  if (job.status === "queued" || job.status === "running") {
+    const terminal = await db.prepare(
+      `UPDATE sync_jobs
+       SET status = ?, finished_at = ?, updated_at = ?
+       WHERE id = ? AND status IN ('queued', 'running')`,
+    ).bind("failed", finishedAt, finishedAt, message.jobId).run();
+    if ((terminal.meta?.changes ?? 0) !== 1) {
+      job = await readJob(db, message.jobId);
+    } else {
+      job = { ...job, status: "failed" };
+    }
+  }
+  if (job?.status !== "failed") {
+    queueMessage.retry();
+    return;
+  }
+
+  await writeUnsupportedLegacyRun(db, job, finishedAt);
+  await writeReceipt(
+    db,
+    runtimeId,
+    queueMessage.id,
+    message.jobId,
+    "rejected",
+    consumedAt,
+    finishedAt,
+  );
+  queueMessage.ack();
+}
+
+async function recoverPreAdapterFailure(
+  db: D1DatabaseLike,
+  queueMessage: QueueMessageLike<unknown>,
+  message: TeamForgeSyncJobMessage,
+  runId: string,
+  runCreated: boolean,
+  runtimeId: string,
+  consumedAt: string,
+  finishedAt: string,
+): Promise<void> {
+  if (runCreated) {
+    await attempt(async () => {
+      await db.prepare(
+        `UPDATE sync_runs
+         SET status = ?, error_code = ?, error_message = ?, finished_at = ?
+         WHERE id = ?`,
+      ).bind(
+        "failed",
+        "sync_adapter_failed",
+        "The selected sync adapter failed.",
+        finishedAt,
+        runId,
+      ).run();
+    });
+  }
+  const exhausted = queueMessage.attempts >= MAX_QUEUE_ATTEMPTS;
+  await attempt(async () => {
+    await db.prepare(
+      `UPDATE sync_jobs
+       SET status = ?, finished_at = ?, updated_at = ?
+       WHERE id = ?`,
+    ).bind(
+      exhausted ? "failed" : "queued",
+      exhausted ? finishedAt : null,
+      finishedAt,
+      message.jobId,
+    ).run();
+  });
+  await attempt(async () => {
+    await writeReceipt(
+      db,
+      runtimeId,
+      queueMessage.id,
+      message.jobId,
+      "failed",
+      consumedAt,
+      finishedAt,
+    );
+  });
+  queueMessage.retry();
+}
+
+async function recoverPostAdapterFailure(
+  db: D1DatabaseLike,
+  queueMessage: QueueMessageLike<unknown>,
+  message: TeamForgeSyncJobMessage,
+  runId: string,
+  runtimeId: string,
+  consumedAt: string,
+  finishedAt: string,
+): Promise<void> {
+  let currentJob: SyncJobRow | null = null;
+  try {
+    currentJob = await readJob(db, message.jobId);
+  } catch {
+    // Continue with bounded best-effort terminal reconciliation.
+  }
+  if (currentJob?.status === "completed") {
+    const receiptWritten = await attempt(async () => {
+      await writeReceipt(
+        db,
+        runtimeId,
+        queueMessage.id,
+        message.jobId,
+        "completed",
+        consumedAt,
+        finishedAt,
+      );
+    });
+    if (receiptWritten) {
+      queueMessage.ack();
+    } else {
+      queueMessage.retry();
+    }
+    return;
+  }
+
+  await attempt(async () => {
+    await db.prepare(
+      `UPDATE sync_runs
+       SET status = ?, error_code = ?, error_message = ?, finished_at = ?
+       WHERE id = ?`,
+    ).bind(
+      "failed",
+      "sync_completion_persistence_failed",
+      "Sync completed externally but terminal persistence requires reconciliation.",
+      finishedAt,
+      runId,
+    ).run();
+  });
+  await attempt(async () => {
+    await db.prepare(
+      `UPDATE sync_jobs
+       SET status = ?, finished_at = ?, updated_at = ?
+       WHERE id = ?`,
+    ).bind("failed", finishedAt, finishedAt, message.jobId).run();
+  });
+  await attempt(async () => {
+    await writeReceipt(
+      db,
+      runtimeId,
+      queueMessage.id,
+      message.jobId,
+      "failed",
+      consumedAt,
+      finishedAt,
+    );
+  });
+  queueMessage.retry();
+}
+
 async function processMessage(
   queueMessage: QueueMessageLike<unknown>,
   env: Env,
@@ -192,7 +451,17 @@ async function processMessage(
   // selecting a source adapter.
   const message = parseSyncJobMessage(queueMessage.body);
   if (!message) {
-    queueMessage.ack();
+    const legacyMessage = parseLegacyTeamSnapshotMessage(queueMessage.body);
+    if (legacyMessage) {
+      await processLegacyTeamSnapshot(
+        queueMessage,
+        env,
+        legacyMessage,
+        dependencies,
+      );
+    } else {
+      queueMessage.ack();
+    }
     return;
   }
 
@@ -232,6 +501,20 @@ async function processMessage(
     queueMessage.ack();
     return;
   }
+  if (job.status === "failed") {
+    const finishedAt = terminalTimestamp(clock);
+    await writeReceipt(
+      db,
+      runtimeId,
+      queueMessage.id,
+      message.jobId,
+      "failed",
+      consumedAt,
+      finishedAt,
+    );
+    queueMessage.ack();
+    return;
+  }
   if (job.status !== "queued") {
     queueMessage.retry();
     return;
@@ -264,23 +547,26 @@ async function processMessage(
   }
 
   const runId = nanoid();
-  await db.prepare(
-    `INSERT INTO sync_runs
-      (id, workspace_id, source, job_id, status, started_at, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
-  ).bind(
-    runId,
-    message.workspaceId,
-    message.source,
-    message.jobId,
-    "running",
-    startedAt,
-    startedAt,
-  ).run();
-
+  let runCreated = false;
+  let adapterCompleted = false;
   try {
+    await db.prepare(
+      `INSERT INTO sync_runs
+        (id, workspace_id, source, job_id, status, started_at, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).bind(
+      runId,
+      message.workspaceId,
+      message.source,
+      message.jobId,
+      "running",
+      startedAt,
+      startedAt,
+    ).run();
+    runCreated = true;
     const runAdapter = dependencies.runAdapter ?? runQueuedProjectSync;
     const stats = await runAdapter(env, message, runId);
+    adapterCompleted = true;
     const finishedAt = terminalTimestamp(clock);
     await db.prepare(
       `UPDATE sync_runs
@@ -308,41 +594,29 @@ async function processMessage(
     );
     queueMessage.ack();
   } catch {
-    // Persist only fixed, bounded evidence. Adapter exceptions can contain
-    // vendor response bodies or credentials and must never enter D1.
     const finishedAt = terminalTimestamp(clock);
-    await db.prepare(
-      `UPDATE sync_runs
-       SET status = ?, error_code = ?, error_message = ?, finished_at = ?
-       WHERE id = ?`,
-    ).bind(
-      "failed",
-      "sync_adapter_failed",
-      "The selected sync adapter failed.",
-      finishedAt,
-      runId,
-    ).run();
-    const exhausted = queueMessage.attempts >= MAX_QUEUE_ATTEMPTS;
-    await db.prepare(
-      `UPDATE sync_jobs
-       SET status = ?, finished_at = ?, updated_at = ?
-       WHERE id = ?`,
-    ).bind(
-      exhausted ? "failed" : "queued",
-      exhausted ? finishedAt : null,
-      finishedAt,
-      message.jobId,
-    ).run();
-    await writeReceipt(
-      db,
-      runtimeId,
-      queueMessage.id,
-      message.jobId,
-      "failed",
-      consumedAt,
-      finishedAt,
-    );
-    queueMessage.retry();
+    if (adapterCompleted) {
+      await recoverPostAdapterFailure(
+        db,
+        queueMessage,
+        message,
+        runId,
+        runtimeId,
+        consumedAt,
+        finishedAt,
+      );
+    } else {
+      await recoverPreAdapterFailure(
+        db,
+        queueMessage,
+        message,
+        runId,
+        runCreated,
+        runtimeId,
+        consumedAt,
+        finishedAt,
+      );
+    }
   }
 }
 

--- a/cloudflare/worker/src/routes/sync.ts
+++ b/cloudflare/worker/src/routes/sync.ts
@@ -1,10 +1,15 @@
 import type { Env } from "../lib/env";
 import { execute, nanoid, now, queryAll, queryFirst } from "../lib/db";
 import { jsonError, jsonOk } from "../lib/response";
+import {
+  SYNC_JOB_SCHEMA_VERSION,
+  parseSyncJobMessage,
+} from "../lib/sync-queue";
 
 interface SyncJob {
   id: string;
   workspace_id: string;
+  project_id: string | null;
   source: string;
   job_type: string;
   status: string;
@@ -34,34 +39,67 @@ interface SyncRun {
 export async function handlePostSyncJob(env: Env, request: Request): Promise<Response> {
   if (!env.TEAMFORGE_DB) return jsonError({ code: "db_unavailable", message: "Database not available.", retryable: true }, 503);
 
-  let body: { workspace_id?: string; source?: string; job_type?: string; requested_by?: string; payload?: unknown };
+  let body: {
+    workspace_id?: string;
+    project_id?: string;
+    source?: string;
+    job_type?: string;
+    requested_by?: string;
+  };
   try {
     body = await request.json();
   } catch {
     return jsonError({ code: "invalid_json", message: "Request body must be valid JSON.", retryable: false }, 400);
   }
 
-  if (!body.workspace_id || !body.source || !body.job_type) {
-    return jsonError({ code: "missing_fields", message: "workspace_id, source, and job_type are required.", retryable: false }, 400);
+  if (!body.workspace_id || !body.project_id || !body.source) {
+    return jsonError({
+      code: "missing_fields",
+      message: "workspace_id, project_id, and source are required.",
+      retryable: false,
+    }, 400);
   }
 
   const validSources = ["clockify", "github", "huly", "slack"];
   if (!validSources.includes(body.source)) {
     return jsonError({ code: "invalid_source", message: `source must be one of: ${validSources.join(", ")}`, retryable: false }, 400);
   }
+  if (body.job_type !== undefined && body.job_type !== "project_sync") {
+    return jsonError({
+      code: "invalid_job_type",
+      message: "job_type must be project_sync.",
+      retryable: false,
+    }, 400);
+  }
 
   const jobId = nanoid();
   const ts = now();
+  const queueMessage = parseSyncJobMessage({
+    schemaVersion: SYNC_JOB_SCHEMA_VERSION,
+    jobId,
+    workspaceId: body.workspace_id,
+    projectId: body.project_id,
+    source: body.source,
+    jobType: "project_sync",
+    requestedAt: ts,
+  });
+  if (!queueMessage) {
+    return jsonError({
+      code: "invalid_fields",
+      message: "workspace_id and project_id must be bounded identifiers.",
+      retryable: false,
+    }, 400);
+  }
 
   await execute(
     env.TEAMFORGE_DB,
-    "INSERT INTO sync_jobs (id, workspace_id, source, job_type, status, payload_json, requested_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    "INSERT INTO sync_jobs (id, workspace_id, project_id, source, job_type, status, requested_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
     jobId,
     body.workspace_id,
+    body.project_id,
     body.source,
-    body.job_type,
+    "project_sync",
     "queued",
-    body.payload ? JSON.stringify(body.payload) : null,
     body.requested_by ?? null,
     ts,
     ts,
@@ -69,12 +107,7 @@ export async function handlePostSyncJob(env: Env, request: Request): Promise<Res
 
   if (env.SYNC_QUEUE) {
     try {
-      await env.SYNC_QUEUE.send({
-        jobId,
-        workspaceId: body.workspace_id,
-        source: body.source as "clockify" | "github" | "huly" | "slack",
-        jobType: body.job_type,
-      });
+      await env.SYNC_QUEUE.send(queueMessage);
       await execute(env.TEAMFORGE_DB, "UPDATE sync_jobs SET queue_message_id = ?, updated_at = ? WHERE id = ?", "enqueued", ts, jobId);
     } catch {
       // queue send failure is non-fatal — job is still recorded

--- a/cloudflare/worker/src/routes/sync.ts
+++ b/cloudflare/worker/src/routes/sync.ts
@@ -75,7 +75,7 @@ export async function handlePostSyncJob(env: Env, request: Request): Promise<Res
   const jobId = nanoid();
   const ts = now();
   const queueMessage = parseSyncJobMessage({
-    schemaVersion: SYNC_JOB_SCHEMA_VERSION,
+    schema: SYNC_JOB_SCHEMA_VERSION,
     jobId,
     workspaceId: body.workspace_id,
     projectId: body.project_id,

--- a/cloudflare/worker/src/routes/sync.ts
+++ b/cloudflare/worker/src/routes/sync.ts
@@ -36,6 +36,43 @@ interface SyncRun {
   created_at: string;
 }
 
+async function persistQueueProducerFailure(
+  env: Env,
+  jobId: string,
+  workspaceId: string,
+  source: string,
+  code: "sync_queue_unavailable" | "sync_queue_send_failed",
+  message: string,
+  timestamp: string,
+): Promise<void> {
+  const db = env.TEAMFORGE_DB!;
+  await execute(
+    db,
+    "UPDATE sync_jobs SET status = ?, finished_at = ?, updated_at = ? WHERE id = ?",
+    "failed",
+    timestamp,
+    timestamp,
+    jobId,
+  );
+  await execute(
+    db,
+    `INSERT INTO sync_runs
+      (id, workspace_id, source, job_id, status, error_code, error_message,
+       started_at, finished_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    nanoid(),
+    workspaceId,
+    source,
+    jobId,
+    "failed",
+    code,
+    message,
+    timestamp,
+    timestamp,
+    timestamp,
+  );
+}
+
 export async function handlePostSyncJob(env: Env, request: Request): Promise<Response> {
   if (!env.TEAMFORGE_DB) return jsonError({ code: "db_unavailable", message: "Database not available.", retryable: true }, 503);
 
@@ -105,13 +142,40 @@ export async function handlePostSyncJob(env: Env, request: Request): Promise<Res
     ts,
   );
 
-  if (env.SYNC_QUEUE) {
-    try {
-      await env.SYNC_QUEUE.send(queueMessage);
-      await execute(env.TEAMFORGE_DB, "UPDATE sync_jobs SET queue_message_id = ?, updated_at = ? WHERE id = ?", "enqueued", ts, jobId);
-    } catch {
-      // queue send failure is non-fatal — job is still recorded
-    }
+  if (!env.SYNC_QUEUE) {
+    await persistQueueProducerFailure(
+      env,
+      jobId,
+      body.workspace_id,
+      body.source,
+      "sync_queue_unavailable",
+      "The sync Queue binding is unavailable.",
+      ts,
+    );
+    return jsonError({
+      code: "sync_queue_unavailable",
+      message: "Sync Queue is unavailable.",
+      retryable: true,
+    }, 503);
+  }
+  try {
+    await env.SYNC_QUEUE.send(queueMessage);
+    await execute(env.TEAMFORGE_DB, "UPDATE sync_jobs SET queue_message_id = ?, updated_at = ? WHERE id = ?", "enqueued", ts, jobId);
+  } catch {
+    await persistQueueProducerFailure(
+      env,
+      jobId,
+      body.workspace_id,
+      body.source,
+      "sync_queue_send_failed",
+      "The sync Queue did not accept the job.",
+      ts,
+    );
+    return jsonError({
+      code: "sync_queue_send_failed",
+      message: "Sync Queue did not accept the job.",
+      retryable: true,
+    }, 503);
   }
 
   const job = await queryFirst<SyncJob>(env.TEAMFORGE_DB, "SELECT * FROM sync_jobs WHERE id = ?", jobId);

--- a/cloudflare/worker/src/routes/v1.ts
+++ b/cloudflare/worker/src/routes/v1.ts
@@ -102,6 +102,7 @@ import {
   handleGithubWebhook,
 } from "./github";
 import { handleGetWeeklyReportingContext } from "./reporting";
+import { getSyncConsumerStatus } from "../lib/control-plane-status";
 
 interface DatabaseStatus {
   available: boolean;
@@ -808,7 +809,10 @@ export async function handleV1Request(request: Request, env: Env, url: URL): Pro
 }
 
 async function buildBootstrapPayload(env: Env): Promise<Record<string, unknown>> {
-  const database = await probeDatabase(env);
+  const [database, syncConsumer] = await Promise.all([
+    probeDatabase(env),
+    getSyncConsumerStatus(env),
+  ]);
   return {
     service: "teamforge-api",
     phase: "phase-2-wave-3",
@@ -820,6 +824,9 @@ async function buildBootstrapPayload(env: Env): Promise<Record<string, unknown>>
       artifactsBound: Boolean(env.TEAMFORGE_ARTIFACTS),
       syncQueueBound: Boolean(env.SYNC_QUEUE),
       workspaceLocksBound: Boolean(env.WORKSPACE_LOCKS),
+    },
+    controlPlaneStatus: {
+      syncConsumer,
     },
     routeStatus: {
       bootstrap: "live",

--- a/cloudflare/worker/wrangler.jsonc
+++ b/cloudflare/worker/wrangler.jsonc
@@ -52,6 +52,15 @@
         "binding": "SYNC_QUEUE",
         "queue": "teamforge-sync"
       }
+    ],
+    "consumers": [
+      {
+        "queue": "teamforge-sync",
+        "max_batch_size": 5,
+        "max_batch_timeout": 5,
+        "max_retries": 3,
+        "dead_letter_queue": "teamforge-sync-dlq"
+      }
     ]
   },
   "durable_objects": {

--- a/scripts/context-projection.test.mjs
+++ b/scripts/context-projection.test.mjs
@@ -14,8 +14,8 @@ import {
 const base = {
   markdown: "# Daily Standup\nBounded evidence",
   generation: 7,
-  generatedAt: "2026-07-28T10:00:00.000Z",
-  validUntil: "2026-07-29T10:00:00.000Z",
+  producedAt: "2026-07-28T10:00:00.000Z",
+  expiresAt: "2026-07-29T10:00:00.000Z",
   sourceRevision: "vault:abc123",
 };
 
@@ -28,8 +28,8 @@ test("builds the frozen projection and hashes exact markdown bytes", () => {
     "tenantId",
     "routine",
     "generation",
-    "generatedAt",
-    "validUntil",
+    "producedAt",
+    "expiresAt",
     "sourceRevision",
     "contentDigest",
     "markdown",
@@ -40,8 +40,8 @@ test("builds the frozen projection and hashes exact markdown bytes", () => {
     tenantId: "cambium",
     routine: "daily-standup-digest",
     generation: 7,
-    generatedAt: "2026-07-28T10:00:00.000Z",
-    validUntil: "2026-07-29T10:00:00.000Z",
+    producedAt: "2026-07-28T10:00:00.000Z",
+    expiresAt: "2026-07-29T10:00:00.000Z",
     sourceRevision: "vault:abc123",
     contentDigest: "sha256:7d696bb44566df0ffec55bce3a17117aa397f923f92e26b91c0695f9fc9fd8e4",
     markdown: base.markdown,
@@ -56,8 +56,8 @@ test("digest changes when the exact markdown bytes change", () => {
 
 test("rejects non-positive generations, invalid times, and expired projections", () => {
   assert.throws(() => buildContextProjection({ ...base, generation: 0 }), /generation/);
-  assert.throws(() => buildContextProjection({ ...base, generatedAt: "today" }), /generatedAt/);
-  assert.throws(() => buildContextProjection({ ...base, validUntil: base.generatedAt }), /validUntil/);
+  assert.throws(() => buildContextProjection({ ...base, producedAt: "today" }), /producedAt/);
+  assert.throws(() => buildContextProjection({ ...base, expiresAt: base.producedAt }), /expiresAt/);
 });
 
 test("enforces source revision and 32 KiB UTF-8 markdown bounds", () => {
@@ -71,8 +71,8 @@ test("dry-run summary excludes markdown and source revision", () => {
     key: CONTEXT_PROJECTION_KEY,
     contentDigest: projection.contentDigest,
     generation: 7,
-    generatedAt: base.generatedAt,
-    validUntil: base.validUntil,
+    producedAt: base.producedAt,
+    expiresAt: base.expiresAt,
   });
 });
 
@@ -126,9 +126,9 @@ test("vault parity projection dry-run prints metadata only", async () => {
         "--projection-source-revision",
         "vault:abc123",
         "--projection-generated-at",
-        base.generatedAt,
+        base.producedAt,
         "--projection-valid-until",
-        base.validUntil,
+        base.expiresAt,
       ],
       { encoding: "utf8" },
     );
@@ -137,8 +137,8 @@ test("vault parity projection dry-run prints metadata only", async () => {
       key: CONTEXT_PROJECTION_KEY,
       contentDigest: "sha256:7d696bb44566df0ffec55bce3a17117aa397f923f92e26b91c0695f9fc9fd8e4",
       generation: 7,
-      generatedAt: base.generatedAt,
-      validUntil: base.validUntil,
+      producedAt: base.producedAt,
+      expiresAt: base.expiresAt,
     });
     assert.equal(result.stdout.includes(base.markdown), false);
     assert.equal(result.stdout.includes("vault:abc123"), false);

--- a/scripts/context-projection.test.mjs
+++ b/scripts/context-projection.test.mjs
@@ -22,16 +22,28 @@ const base = {
 test("builds the frozen projection and hashes exact markdown bytes", () => {
   const projection = buildContextProjection(base);
   assert.equal(Buffer.byteLength(base.markdown, "utf8"), 32);
+  assert.deepEqual(Object.keys(projection).sort(), [
+    "schema",
+    "key",
+    "tenantId",
+    "routine",
+    "generation",
+    "generatedAt",
+    "validUntil",
+    "sourceRevision",
+    "contentDigest",
+    "markdown",
+  ].sort());
   assert.deepEqual(projection, {
-    schemaVersion: "thoughtseed.context-projection.v1",
+    schema: "thoughtseed.context-projection.v1",
     key: CONTEXT_PROJECTION_KEY,
-    tenant: "cambium",
+    tenantId: "cambium",
     routine: "daily-standup-digest",
     generation: 7,
     generatedAt: "2026-07-28T10:00:00.000Z",
     validUntil: "2026-07-29T10:00:00.000Z",
     sourceRevision: "vault:abc123",
-    digest: "sha256:7d696bb44566df0ffec55bce3a17117aa397f923f92e26b91c0695f9fc9fd8e4",
+    contentDigest: "sha256:7d696bb44566df0ffec55bce3a17117aa397f923f92e26b91c0695f9fc9fd8e4",
     markdown: base.markdown,
   });
 });
@@ -39,7 +51,7 @@ test("builds the frozen projection and hashes exact markdown bytes", () => {
 test("digest changes when the exact markdown bytes change", () => {
   const lf = buildContextProjection(base);
   const crlf = buildContextProjection({ ...base, markdown: base.markdown.replace("\n", "\r\n") });
-  assert.notEqual(lf.digest, crlf.digest);
+  assert.notEqual(lf.contentDigest, crlf.contentDigest);
 });
 
 test("rejects non-positive generations, invalid times, and expired projections", () => {
@@ -57,7 +69,7 @@ test("dry-run summary excludes markdown and source revision", () => {
   const projection = buildContextProjection(base);
   assert.deepEqual(summarizeContextProjection(projection), {
     key: CONTEXT_PROJECTION_KEY,
-    digest: projection.digest,
+    contentDigest: projection.contentDigest,
     generation: 7,
     generatedAt: base.generatedAt,
     validUntil: base.validUntil,
@@ -84,6 +96,7 @@ test("apply requires named URL/token environment variables and never returns the
   assert.equal(calls.length, 1);
   assert.equal(calls[0].url, "https://example.test/context");
   assert.equal(calls[0].init.headers.authorization, "Bearer top-secret");
+  assert.deepEqual(JSON.parse(calls[0].init.body), projection);
   assert.equal(result.applied, true);
   assert.equal(JSON.stringify(result).includes("top-secret"), false);
 
@@ -122,7 +135,7 @@ test("vault parity projection dry-run prints metadata only", async () => {
     assert.equal(result.status, 0, result.stderr);
     assert.deepEqual(JSON.parse(result.stdout), {
       key: CONTEXT_PROJECTION_KEY,
-      digest: "sha256:7d696bb44566df0ffec55bce3a17117aa397f923f92e26b91c0695f9fc9fd8e4",
+      contentDigest: "sha256:7d696bb44566df0ffec55bce3a17117aa397f923f92e26b91c0695f9fc9fd8e4",
       generation: 7,
       generatedAt: base.generatedAt,
       validUntil: base.validUntil,

--- a/scripts/context-projection.test.mjs
+++ b/scripts/context-projection.test.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  CONTEXT_PROJECTION_KEY,
+  applyContextProjection,
+  buildContextProjection,
+  summarizeContextProjection,
+} from "./lib/context-projection.mjs";
+
+const base = {
+  markdown: "# Daily Standup\nBounded evidence",
+  generation: 7,
+  generatedAt: "2026-07-28T10:00:00.000Z",
+  validUntil: "2026-07-29T10:00:00.000Z",
+  sourceRevision: "vault:abc123",
+};
+
+test("builds the frozen projection and hashes exact markdown bytes", () => {
+  const projection = buildContextProjection(base);
+  assert.equal(Buffer.byteLength(base.markdown, "utf8"), 32);
+  assert.deepEqual(projection, {
+    schemaVersion: "thoughtseed.context-projection.v1",
+    key: CONTEXT_PROJECTION_KEY,
+    tenant: "cambium",
+    routine: "daily-standup-digest",
+    generation: 7,
+    generatedAt: "2026-07-28T10:00:00.000Z",
+    validUntil: "2026-07-29T10:00:00.000Z",
+    sourceRevision: "vault:abc123",
+    digest: "sha256:7d696bb44566df0ffec55bce3a17117aa397f923f92e26b91c0695f9fc9fd8e4",
+    markdown: base.markdown,
+  });
+});
+
+test("digest changes when the exact markdown bytes change", () => {
+  const lf = buildContextProjection(base);
+  const crlf = buildContextProjection({ ...base, markdown: base.markdown.replace("\n", "\r\n") });
+  assert.notEqual(lf.digest, crlf.digest);
+});
+
+test("rejects non-positive generations, invalid times, and expired projections", () => {
+  assert.throws(() => buildContextProjection({ ...base, generation: 0 }), /generation/);
+  assert.throws(() => buildContextProjection({ ...base, generatedAt: "today" }), /generatedAt/);
+  assert.throws(() => buildContextProjection({ ...base, validUntil: base.generatedAt }), /validUntil/);
+});
+
+test("enforces source revision and 32 KiB UTF-8 markdown bounds", () => {
+  assert.throws(() => buildContextProjection({ ...base, sourceRevision: "x".repeat(129) }), /sourceRevision/);
+  assert.throws(() => buildContextProjection({ ...base, markdown: "💡".repeat(8_193) }), /markdown/);
+});
+
+test("dry-run summary excludes markdown and source revision", () => {
+  const projection = buildContextProjection(base);
+  assert.deepEqual(summarizeContextProjection(projection), {
+    key: CONTEXT_PROJECTION_KEY,
+    digest: projection.digest,
+    generation: 7,
+    generatedAt: base.generatedAt,
+    validUntil: base.validUntil,
+  });
+});
+
+test("apply requires named URL/token environment variables and never returns the token", async () => {
+  const projection = buildContextProjection(base);
+  const calls = [];
+  const result = await applyContextProjection(projection, {
+    apply: true,
+    urlEnvName: "PROJECTION_URL",
+    tokenEnvName: "PROJECTION_TOKEN",
+    env: {
+      PROJECTION_URL: "https://example.test/context",
+      PROJECTION_TOKEN: "top-secret",
+    },
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return new Response(null, { status: 202 });
+    },
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://example.test/context");
+  assert.equal(calls[0].init.headers.authorization, "Bearer top-secret");
+  assert.equal(result.applied, true);
+  assert.equal(JSON.stringify(result).includes("top-secret"), false);
+
+  await assert.rejects(
+    applyContextProjection(projection, {
+      apply: true,
+      env: {},
+      fetchImpl: async () => new Response(null, { status: 202 }),
+    }),
+    /environment variable names/,
+  );
+});
+
+test("vault parity projection dry-run prints metadata only", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "teamforge-projection-"));
+  try {
+    const markdownPath = path.join(tempDir, "standup.md");
+    await writeFile(markdownPath, base.markdown, "utf8");
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.resolve("scripts/teamforge-vault-parity.mjs"),
+        "--context-projection",
+        markdownPath,
+        "--projection-generation",
+        "7",
+        "--projection-source-revision",
+        "vault:abc123",
+        "--projection-generated-at",
+        base.generatedAt,
+        "--projection-valid-until",
+        base.validUntil,
+      ],
+      { encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout), {
+      key: CONTEXT_PROJECTION_KEY,
+      digest: "sha256:7d696bb44566df0ffec55bce3a17117aa397f923f92e26b91c0695f9fc9fd8e4",
+      generation: 7,
+      generatedAt: base.generatedAt,
+      validUntil: base.validUntil,
+    });
+    assert.equal(result.stdout.includes(base.markdown), false);
+    assert.equal(result.stdout.includes("vault:abc123"), false);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/context-projection.test.mjs
+++ b/scripts/context-projection.test.mjs
@@ -62,6 +62,8 @@ test("rejects non-positive generations, invalid times, and expired projections",
 
 test("enforces source revision and 32 KiB UTF-8 markdown bounds", () => {
   assert.throws(() => buildContextProjection({ ...base, sourceRevision: "x".repeat(129) }), /sourceRevision/);
+  assert.throws(() => buildContextProjection({ ...base, sourceRevision: " revision " }), /sourceRevision/);
+  assert.throws(() => buildContextProjection({ ...base, sourceRevision: "revision\nnext" }), /sourceRevision/);
   assert.throws(() => buildContextProjection({ ...base, markdown: "💡".repeat(8_193) }), /markdown/);
 });
 
@@ -108,6 +110,29 @@ test("apply requires named URL/token environment variables and never returns the
     }),
     /environment variable names/,
   );
+});
+
+test("apply rejects HTTP endpoints before fetch to protect the bearer", async () => {
+  const projection = buildContextProjection(base);
+  let fetchCalled = false;
+
+  await assert.rejects(
+    applyContextProjection(projection, {
+      apply: true,
+      urlEnvName: "PROJECTION_URL",
+      tokenEnvName: "PROJECTION_TOKEN",
+      env: {
+        PROJECTION_URL: "http://example.test/context",
+        PROJECTION_TOKEN: "top-secret",
+      },
+      fetchImpl: async () => {
+        fetchCalled = true;
+        return new Response(null, { status: 202 });
+      },
+    }),
+    /HTTPS/,
+  );
+  assert.equal(fetchCalled, false);
 });
 
 test("vault parity projection dry-run prints metadata only", async () => {

--- a/scripts/lib/context-projection.mjs
+++ b/scripts/lib/context-projection.mjs
@@ -28,8 +28,8 @@ function requireCanonicalTimestamp(value, fieldName) {
 export function buildContextProjection({
   markdown,
   generation,
-  generatedAt,
-  validUntil,
+  producedAt,
+  expiresAt,
   sourceRevision,
 }) {
   if (typeof markdown !== "string" || utf8Bytes(markdown) > MAX_MARKDOWN_BYTES) {
@@ -38,10 +38,10 @@ export function buildContextProjection({
   if (!Number.isSafeInteger(generation) || generation <= 0) {
     throw new TypeError("generation must be a positive safe integer.");
   }
-  const normalizedGeneratedAt = requireCanonicalTimestamp(generatedAt, "generatedAt");
-  const normalizedValidUntil = requireCanonicalTimestamp(validUntil, "validUntil");
-  if (Date.parse(normalizedValidUntil) <= Date.parse(normalizedGeneratedAt)) {
-    throw new TypeError("validUntil must be later than generatedAt.");
+  const normalizedProducedAt = requireCanonicalTimestamp(producedAt, "producedAt");
+  const normalizedExpiresAt = requireCanonicalTimestamp(expiresAt, "expiresAt");
+  if (Date.parse(normalizedExpiresAt) <= Date.parse(normalizedProducedAt)) {
+    throw new TypeError("expiresAt must be later than producedAt.");
   }
   if (
     typeof sourceRevision !== "string"
@@ -62,8 +62,8 @@ export function buildContextProjection({
     tenantId: CONTEXT_PROJECTION_TENANT,
     routine: CONTEXT_PROJECTION_ROUTINE,
     generation,
-    generatedAt: normalizedGeneratedAt,
-    validUntil: normalizedValidUntil,
+    producedAt: normalizedProducedAt,
+    expiresAt: normalizedExpiresAt,
     sourceRevision,
     contentDigest,
     markdown,
@@ -75,8 +75,8 @@ export function summarizeContextProjection(projection) {
     key: projection.key,
     contentDigest: projection.contentDigest,
     generation: projection.generation,
-    generatedAt: projection.generatedAt,
-    validUntil: projection.validUntil,
+    producedAt: projection.producedAt,
+    expiresAt: projection.expiresAt,
   };
 }
 

--- a/scripts/lib/context-projection.mjs
+++ b/scripts/lib/context-projection.mjs
@@ -46,9 +46,13 @@ export function buildContextProjection({
   if (
     typeof sourceRevision !== "string"
     || sourceRevision.length === 0
+    || sourceRevision.trim() !== sourceRevision
+    || /\p{Cc}/u.test(sourceRevision)
     || utf8Bytes(sourceRevision) > MAX_SOURCE_REVISION_BYTES
   ) {
-    throw new TypeError("sourceRevision must contain 1-128 UTF-8 bytes.");
+    throw new TypeError(
+      "sourceRevision must contain 1-128 trimmed, control-free UTF-8 bytes.",
+    );
   }
 
   // Do not normalize line endings, trim, or otherwise mutate markdown. The
@@ -103,8 +107,8 @@ export async function applyContextProjection(
     throw new TypeError("The named projection URL and token environment variables must be set.");
   }
   const url = new URL(urlValue);
-  if (!["https:", "http:"].includes(url.protocol)) {
-    throw new TypeError("The projection URL must use HTTP or HTTPS.");
+  if (url.protocol !== "https:") {
+    throw new TypeError("The projection URL must use HTTPS.");
   }
   const response = await fetchImpl(url.href, {
     method: "POST",

--- a/scripts/lib/context-projection.mjs
+++ b/scripts/lib/context-projection.mjs
@@ -53,19 +53,19 @@ export function buildContextProjection({
 
   // Do not normalize line endings, trim, or otherwise mutate markdown. The
   // digest is defined over its exact UTF-8 bytes.
-  const digest = `sha256:${createHash("sha256").update(
+  const contentDigest = `sha256:${createHash("sha256").update(
     Buffer.from(markdown, "utf8"),
   ).digest("hex")}`;
   return {
-    schemaVersion: CONTEXT_PROJECTION_SCHEMA_VERSION,
+    schema: CONTEXT_PROJECTION_SCHEMA_VERSION,
     key: CONTEXT_PROJECTION_KEY,
-    tenant: CONTEXT_PROJECTION_TENANT,
+    tenantId: CONTEXT_PROJECTION_TENANT,
     routine: CONTEXT_PROJECTION_ROUTINE,
     generation,
     generatedAt: normalizedGeneratedAt,
     validUntil: normalizedValidUntil,
     sourceRevision,
-    digest,
+    contentDigest,
     markdown,
   };
 }
@@ -73,7 +73,7 @@ export function buildContextProjection({
 export function summarizeContextProjection(projection) {
   return {
     key: projection.key,
-    digest: projection.digest,
+    contentDigest: projection.contentDigest,
     generation: projection.generation,
     generatedAt: projection.generatedAt,
     validUntil: projection.validUntil,

--- a/scripts/lib/context-projection.mjs
+++ b/scripts/lib/context-projection.mjs
@@ -1,0 +1,125 @@
+import { createHash } from "node:crypto";
+
+export const CONTEXT_PROJECTION_SCHEMA_VERSION =
+  "thoughtseed.context-projection.v1";
+export const CONTEXT_PROJECTION_KEY =
+  "context/v1/daily-standup-digest/standups/latest.json";
+export const CONTEXT_PROJECTION_TENANT = "cambium";
+export const CONTEXT_PROJECTION_ROUTINE = "daily-standup-digest";
+
+const MAX_MARKDOWN_BYTES = 32 * 1024;
+const MAX_SOURCE_REVISION_BYTES = 128;
+
+function utf8Bytes(value) {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function requireCanonicalTimestamp(value, fieldName) {
+  if (
+    typeof value !== "string"
+    || !Number.isFinite(Date.parse(value))
+    || new Date(Date.parse(value)).toISOString() !== value
+  ) {
+    throw new TypeError(`${fieldName} must be a canonical ISO-8601 timestamp.`);
+  }
+  return value;
+}
+
+export function buildContextProjection({
+  markdown,
+  generation,
+  generatedAt,
+  validUntil,
+  sourceRevision,
+}) {
+  if (typeof markdown !== "string" || utf8Bytes(markdown) > MAX_MARKDOWN_BYTES) {
+    throw new TypeError("markdown must be a string no larger than 32 KiB UTF-8.");
+  }
+  if (!Number.isSafeInteger(generation) || generation <= 0) {
+    throw new TypeError("generation must be a positive safe integer.");
+  }
+  const normalizedGeneratedAt = requireCanonicalTimestamp(generatedAt, "generatedAt");
+  const normalizedValidUntil = requireCanonicalTimestamp(validUntil, "validUntil");
+  if (Date.parse(normalizedValidUntil) <= Date.parse(normalizedGeneratedAt)) {
+    throw new TypeError("validUntil must be later than generatedAt.");
+  }
+  if (
+    typeof sourceRevision !== "string"
+    || sourceRevision.length === 0
+    || utf8Bytes(sourceRevision) > MAX_SOURCE_REVISION_BYTES
+  ) {
+    throw new TypeError("sourceRevision must contain 1-128 UTF-8 bytes.");
+  }
+
+  // Do not normalize line endings, trim, or otherwise mutate markdown. The
+  // digest is defined over its exact UTF-8 bytes.
+  const digest = `sha256:${createHash("sha256").update(
+    Buffer.from(markdown, "utf8"),
+  ).digest("hex")}`;
+  return {
+    schemaVersion: CONTEXT_PROJECTION_SCHEMA_VERSION,
+    key: CONTEXT_PROJECTION_KEY,
+    tenant: CONTEXT_PROJECTION_TENANT,
+    routine: CONTEXT_PROJECTION_ROUTINE,
+    generation,
+    generatedAt: normalizedGeneratedAt,
+    validUntil: normalizedValidUntil,
+    sourceRevision,
+    digest,
+    markdown,
+  };
+}
+
+export function summarizeContextProjection(projection) {
+  return {
+    key: projection.key,
+    digest: projection.digest,
+    generation: projection.generation,
+    generatedAt: projection.generatedAt,
+    validUntil: projection.validUntil,
+  };
+}
+
+export async function applyContextProjection(
+  projection,
+  {
+    apply = false,
+    urlEnvName,
+    tokenEnvName,
+    env = process.env,
+    fetchImpl = fetch,
+  } = {},
+) {
+  const summary = summarizeContextProjection(projection);
+  if (!apply) return summary;
+  if (!urlEnvName || !tokenEnvName) {
+    throw new TypeError(
+      "Explicit URL and token environment variable names are required for --apply.",
+    );
+  }
+  const urlValue = env[urlEnvName];
+  const tokenValue = env[tokenEnvName];
+  if (!urlValue || !tokenValue) {
+    throw new TypeError("The named projection URL and token environment variables must be set.");
+  }
+  const url = new URL(urlValue);
+  if (!["https:", "http:"].includes(url.protocol)) {
+    throw new TypeError("The projection URL must use HTTP or HTTPS.");
+  }
+  const response = await fetchImpl(url.href, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${tokenValue}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(projection),
+  });
+  if (!response.ok) {
+    throw new Error(`Projection POST failed with HTTP ${response.status}.`);
+  }
+  return {
+    ...summary,
+    applied: true,
+    status: response.status,
+  };
+}

--- a/scripts/teamforge-vault-parity.mjs
+++ b/scripts/teamforge-vault-parity.mjs
@@ -19,6 +19,10 @@ import path from "node:path";
 import process from "node:process";
 import { DatabaseSync } from "node:sqlite";
 import { pathToFileURL } from "node:url";
+import {
+  applyContextProjection,
+  buildContextProjection,
+} from "./lib/context-projection.mjs";
 
 const DEFAULT_VAULT_ROOT =
   "/Volumes/madara/2026/twc-vault/01-Projects/thoughtseed/thoughtseed-labs";
@@ -60,6 +64,13 @@ Options:
   --internal-secret <secret> Temporary shared secret for m2m internal auth (X-TeamForge-Internal-Secret header). Use when CF Access service tokens have issues with the Worker route (also via TF_INTERNAL_SHARED_SECRET env). For use with IP bypass or other Access-passing methods.
   --project <slug>           Limit to one or more project_id values.
   --report <path>            Write JSON report to disk.
+  --context-projection <path> Build a daily-standup projection from exact Markdown bytes.
+  --projection-generation <n> Positive projection generation (default: current epoch milliseconds).
+  --projection-source-revision <revision> Bounded source revision for projection provenance.
+  --projection-generated-at <timestamp> Canonical generation timestamp.
+  --projection-valid-until <timestamp> Canonical expiry timestamp.
+  --projection-url-env <name> Environment variable containing apply URL.
+  --projection-token-env <name> Environment variable containing apply bearer.
   --help                     Show this help.
 
 Examples:
@@ -68,6 +79,8 @@ Examples:
   node scripts/teamforge-vault-parity.mjs --workspace-id tf-prod --apply
   node scripts/teamforge-vault-parity.mjs --local-only --apply --teamforge-db ~/Library/Application\\ Support/com.thoughtseed.teamforge/teamforge.db
   node scripts/teamforge-vault-parity.mjs --project axtech --project heyzack --report /tmp/teamforge-parity.json
+  node scripts/teamforge-vault-parity.mjs --context-projection /tmp/standup.md
+  node scripts/teamforge-vault-parity.mjs --context-projection /tmp/standup.md --apply --projection-url-env PROJECTION_URL --projection-token-env PROJECTION_TOKEN
 `);
 }
 
@@ -85,6 +98,13 @@ function parseArgs(argv) {
     internalSecret: process.env.TF_INTERNAL_SHARED_SECRET ?? null,
     projects: new Set(),
     reportPath: null,
+    contextProjectionPath: null,
+    projectionGeneration: null,
+    projectionSourceRevision: "teamforge-vault-parity",
+    projectionGeneratedAt: null,
+    projectionValidUntil: null,
+    projectionUrlEnvName: null,
+    projectionTokenEnvName: null,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -139,6 +159,34 @@ function parseArgs(argv) {
     }
     if (value === "--report") {
       args.reportPath = argv[++index];
+      continue;
+    }
+    if (value === "--context-projection") {
+      args.contextProjectionPath = argv[++index];
+      continue;
+    }
+    if (value === "--projection-generation") {
+      args.projectionGeneration = Number(argv[++index]);
+      continue;
+    }
+    if (value === "--projection-source-revision") {
+      args.projectionSourceRevision = argv[++index];
+      continue;
+    }
+    if (value === "--projection-generated-at") {
+      args.projectionGeneratedAt = argv[++index];
+      continue;
+    }
+    if (value === "--projection-valid-until") {
+      args.projectionValidUntil = argv[++index];
+      continue;
+    }
+    if (value === "--projection-url-env") {
+      args.projectionUrlEnvName = argv[++index];
+      continue;
+    }
+    if (value === "--projection-token-env") {
+      args.projectionTokenEnvName = argv[++index];
       continue;
     }
     throw new Error(`Unknown argument: ${value}`);
@@ -1984,8 +2032,35 @@ async function maybeWriteReport(reportPath, report) {
   await fs.writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
 }
 
+async function runContextProjection(args) {
+  const markdown = await fs.readFile(args.contextProjectionPath, "utf8");
+  const generated = args.projectionGeneratedAt
+    ? new Date(args.projectionGeneratedAt)
+    : new Date();
+  const generatedAt = generated.toISOString();
+  const validUntil = args.projectionValidUntil
+    ?? new Date(generated.getTime() + 24 * 60 * 60 * 1_000).toISOString();
+  const projection = buildContextProjection({
+    markdown,
+    generation: args.projectionGeneration ?? generated.getTime(),
+    generatedAt,
+    validUntil,
+    sourceRevision: args.projectionSourceRevision,
+  });
+  const result = await applyContextProjection(projection, {
+    apply: args.apply,
+    urlEnvName: args.projectionUrlEnvName,
+    tokenEnvName: args.projectionTokenEnvName,
+  });
+  console.log(JSON.stringify(result, null, 2));
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
+  if (args.contextProjectionPath) {
+    await runContextProjection(args);
+    return;
+  }
   const clientRoot = path.join(args.vaultRoot, "60-client-ecosystem");
   const teamRoot = path.join(args.vaultRoot, "50-team");
   const token =

--- a/scripts/teamforge-vault-parity.mjs
+++ b/scripts/teamforge-vault-parity.mjs
@@ -2043,8 +2043,8 @@ async function runContextProjection(args) {
   const projection = buildContextProjection({
     markdown,
     generation: args.projectionGeneration ?? generated.getTime(),
-    generatedAt,
-    validUntil,
+    producedAt: generatedAt,
+    expiresAt: validUntil,
     sourceRevision: args.projectionSourceRevision,
   });
   const result = await applyContextProjection(projection, {


### PR DESCRIPTION
## Summary

- add real Queue consumption with terminal sync-job and run ownership
- persist bounded runtime-consumer receipts through additive migration 0017
- derive control-plane health from durable receipt evidence
- add dry-run-first, HTTPS-only context projection publication

## Verification

- Worker suite: 198 passed
- Worker TypeScript check passed
- projection publisher suite: 8 passed
- all 17 migrations replayed in fresh local D1
- frozen ten-field envelope accepted by the Cambium validator

## Release boundary

Worker release. Replay production schema, capture D1 backup, apply migration 0017, confirm teamforge-sync-dlq, then deploy. Projection apply stays disabled until Cambium v1 is live. No desktop tag.